### PR TITLE
fix: Remove space prefix of catchphrase and BS

### DIFF
--- a/company.go
+++ b/company.go
@@ -73,16 +73,22 @@ type Company struct {
 }
 
 func (c Company) CatchPhrase() (phrase string) {
-	for _, words := range catchPhraseWords {
-		phrase = phrase + " " + c.Faker.RandomStringElement(words)
+	for i, words := range catchPhraseWords {
+		if i > 0 {
+			phrase += " "
+		}
+		phrase += c.Faker.RandomStringElement(words)
 	}
 
 	return
 }
 
 func (c Company) BS() (bs string) {
-	for _, words := range catchPhraseWords {
-		bs = bs + " " + c.Faker.RandomStringElement(words)
+	for i, words := range catchPhraseWords {
+		if i > 0 {
+			bs += " "
+		}
+		bs += c.Faker.RandomStringElement(words)
 	}
 
 	return

--- a/company_test.go
+++ b/company_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -8,12 +9,14 @@ func TestCompanyCatchPhrase(t *testing.T) {
 	f := New().Company()
 	phrase := f.CatchPhrase()
 	Expect(t, true, len(phrase) > 0)
+	Expect(t, 2, strings.Count(phrase, " ")) // 3 words
 }
 
 func TestCompanyBS(t *testing.T) {
 	f := New().Company()
 	bs := f.BS()
 	Expect(t, true, len(bs) > 0)
+	Expect(t, 2, strings.Count(bs, " ")) // 3 words
 }
 
 func TestCompanySuffix(t *testing.T) {


### PR DESCRIPTION
Improvement for `Company.CatchPhrase()` and `Company.BS()`.
Removes the empty space before the generated string, and adds tests for the number of words