### PR TITLE
[ADD] gender that related to her/his name

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -170,7 +170,10 @@ func (f Faker) Lorem() Lorem {
 }
 
 func (f Faker) Person() Person {
-	return Person{&f}
+	return Person{
+		Faker:  &f,
+		gender: "Male", // default
+	}
 }
 
 func (f Faker) Address() Address {

--- a/faker.go
+++ b/faker.go
@@ -171,8 +171,7 @@ func (f Faker) Lorem() Lorem {
 
 func (f Faker) Person() Person {
 	return Person{
-		Faker:  &f,
-		gender: "Male", // default
+		Faker: &f,
 	}
 }
 

--- a/faker.go
+++ b/faker.go
@@ -170,9 +170,7 @@ func (f Faker) Lorem() Lorem {
 }
 
 func (f Faker) Person() Person {
-	return Person{
-		Faker: &f,
-	}
+	return Person{&f}
 }
 
 func (f Faker) Address() Address {

--- a/person.go
+++ b/person.go
@@ -124,6 +124,16 @@ func (p Person) TitleFemale() string {
 	return "Ms."
 }
 
+// GenderMale returns a fake GenderMale for Person
+func (p Person) GenderMale() string {
+	return "Male"
+}
+
+// GenderFemale returns a fake GenderFemale for Person
+func (p Person) GenderFemale() string {
+	return "Female"
+}
+
 // Title returns a fake title for Person
 func (p Person) Title() string {
 	if p.Faker.IntBetween(0, 1) == 0 {
@@ -195,14 +205,26 @@ func (p Person) Name() string {
 	return name
 }
 
+// NameMale returns a fake NameMale for Person
 func (p Person) NameMale() string {
 	return fmt.Sprintf("%s %s", p.FirstNameMale(), p.LastName())
 }
 
+// NameFemale returns a fake NameFemale for Person
 func (p Person) NameFemale() string {
 	return fmt.Sprintf("%s %s", p.FirstNameFemale(), p.LastName())
 }
 
+// Gender returns a fake Gender for Person
 func (p Person) Gender() string {
 	return p.Faker.RandomStringElement(gender)
+}
+
+// NameAndGender returns a fake NameAndGender for Person
+func (p Person) NameAndGender() (string, string) {
+	if p.Faker.Boolean().Bool() {
+		return p.NameMale(), p.GenderMale()
+	}
+
+	return p.NameFemale(), p.GenderFemale()
 }

--- a/person.go
+++ b/person.go
@@ -111,10 +111,12 @@ func (p *Person) Suffix() string {
 }
 
 func (p *Person) TitleMale() string {
+	p.gender = "Male"
 	return "Mr."
 }
 
 func (p *Person) TitleFemale() string {
+	p.gender = "Female"
 	return "Ms."
 }
 
@@ -127,11 +129,13 @@ func (p *Person) Title() string {
 }
 
 func (p *Person) FirstNameMale() string {
+	p.gender = "Male"
 	index := p.Faker.IntBetween(0, len(firstNameMale)-1)
 	return firstNameMale[index]
 }
 
 func (p *Person) FirstNameFemale() string {
+	p.gender = "Female"
 	index := p.Faker.IntBetween(0, len(firstNameFemale)-1)
 	return firstNameFemale[index]
 }

--- a/person.go
+++ b/person.go
@@ -105,7 +105,7 @@ var (
 )
 
 type Person struct {
-	*Faker
+	Faker *Faker
 }
 
 func (p Person) Suffix() string {

--- a/person.go
+++ b/person.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -99,28 +100,27 @@ var (
 		"Zboncak", "Zemlak", "Ziemann", "Zieme", "Zulauf"}
 
 	suffix = []string{"Jr.", "Sr.", "I", "II", "III", "IV", "V", "MD", "DDS", "PhD", "DVM"}
+
+	gender = []string{"Male", "Female"}
 )
 
 type Person struct {
-	Faker  *Faker
-	gender string
+	*Faker
 }
 
-func (p *Person) Suffix() string {
+func (p Person) Suffix() string {
 	return suffix[p.Faker.IntBetween(0, len(suffix)-1)]
 }
 
-func (p *Person) TitleMale() string {
-	p.gender = "Male"
+func (p Person) TitleMale() string {
 	return "Mr."
 }
 
-func (p *Person) TitleFemale() string {
-	p.gender = "Female"
+func (p Person) TitleFemale() string {
 	return "Ms."
 }
 
-func (p *Person) Title() string {
+func (p Person) Title() string {
 	if p.Faker.IntBetween(0, 1) == 0 {
 		return p.TitleMale()
 	}
@@ -128,55 +128,48 @@ func (p *Person) Title() string {
 	return p.TitleFemale()
 }
 
-func (p *Person) FirstNameMale() string {
-	p.gender = "Male"
+func (p Person) FirstNameMale() string {
 	index := p.Faker.IntBetween(0, len(firstNameMale)-1)
 	return firstNameMale[index]
 }
 
-func (p *Person) FirstNameFemale() string {
-	p.gender = "Female"
+func (p Person) FirstNameFemale() string {
 	index := p.Faker.IntBetween(0, len(firstNameFemale)-1)
 	return firstNameFemale[index]
 }
 
-func (p *Person) FirstName() string {
+func (p Person) FirstName() string {
 	names := append(firstNameMale, firstNameFemale...)
 	return p.Faker.RandomStringElement(names)
 }
 
-func (p *Person) LastName() string {
+func (p Person) LastName() string {
 	index := p.Faker.IntBetween(0, len(lastName)-1)
 	return lastName[index]
 }
 
-func (p *Person) Name() string {
+func (p Person) Name() string {
 	formats := append(maleNameFormats, femaleNameFormats...)
 	name := formats[p.Faker.IntBetween(0, len(formats)-1)]
-	var gender string
 
 	// {{titleMale}}
 	if strings.Contains(name, "{{titleMale}}") {
 		name = strings.Replace(name, "{{titleMale}}", p.TitleMale(), 1)
-		gender = "Male"
 	}
 
 	//{{firstNameMale}}
 	if strings.Contains(name, "{{firstNameMale}}") {
 		name = strings.Replace(name, "{{firstNameMale}}", p.FirstNameMale(), 1)
-		gender = "Male"
 	}
 
 	// {{titleFemale}}
 	if strings.Contains(name, "{{titleFemale}}") {
 		name = strings.Replace(name, "{{titleFemale}}", p.TitleFemale(), 1)
-		gender = "Female"
 	}
 
 	//{{firstNameFemale}}
 	if strings.Contains(name, "{{firstNameFemale}}") {
 		name = strings.Replace(name, "{{firstNameFemale}}", p.FirstNameFemale(), 1)
-		gender = "Female"
 	}
 
 	//{{lastName}}
@@ -189,12 +182,17 @@ func (p *Person) Name() string {
 		name = strings.Replace(name, "{{suffix}}", p.Suffix(), 1)
 	}
 
-	p.gender = gender
-
 	return name
 }
 
-func (p *Person) Gender() string {
-	gender := p.gender
-	return gender
+func (p Person) NameMale() string {
+	return fmt.Sprintf("%s %s", p.FirstNameMale(), p.LastName())
+}
+
+func (p Person) NameFemale() string {
+	return fmt.Sprintf("%s %s", p.FirstNameFemale(), p.LastName())
+}
+
+func (p Person) Gender() string {
+	return p.Faker.RandomStringElement(gender)
 }

--- a/person.go
+++ b/person.go
@@ -102,22 +102,23 @@ var (
 )
 
 type Person struct {
-	Faker *Faker
+	Faker  *Faker
+	gender string
 }
 
-func (p Person) Suffix() string {
+func (p *Person) Suffix() string {
 	return suffix[p.Faker.IntBetween(0, len(suffix)-1)]
 }
 
-func (p Person) TitleMale() string {
+func (p *Person) TitleMale() string {
 	return "Mr."
 }
 
-func (p Person) TitleFemale() string {
+func (p *Person) TitleFemale() string {
 	return "Ms."
 }
 
-func (p Person) Title() string {
+func (p *Person) Title() string {
 	if p.Faker.IntBetween(0, 1) == 0 {
 		return p.TitleMale()
 	}
@@ -125,48 +126,53 @@ func (p Person) Title() string {
 	return p.TitleFemale()
 }
 
-func (p Person) FirstNameMale() string {
+func (p *Person) FirstNameMale() string {
 	index := p.Faker.IntBetween(0, len(firstNameMale)-1)
 	return firstNameMale[index]
 }
 
-func (p Person) FirstNameFemale() string {
+func (p *Person) FirstNameFemale() string {
 	index := p.Faker.IntBetween(0, len(firstNameFemale)-1)
 	return firstNameFemale[index]
 }
 
-func (p Person) FirstName() string {
+func (p *Person) FirstName() string {
 	names := append(firstNameMale, firstNameFemale...)
 	return p.Faker.RandomStringElement(names)
 }
 
-func (p Person) LastName() string {
+func (p *Person) LastName() string {
 	index := p.Faker.IntBetween(0, len(lastName)-1)
 	return lastName[index]
 }
 
-func (p Person) Name() string {
+func (p *Person) Name() string {
 	formats := append(maleNameFormats, femaleNameFormats...)
 	name := formats[p.Faker.IntBetween(0, len(formats)-1)]
+	var gender string
 
 	// {{titleMale}}
 	if strings.Contains(name, "{{titleMale}}") {
 		name = strings.Replace(name, "{{titleMale}}", p.TitleMale(), 1)
+		gender = "Male"
 	}
 
 	//{{firstNameMale}}
 	if strings.Contains(name, "{{firstNameMale}}") {
 		name = strings.Replace(name, "{{firstNameMale}}", p.FirstNameMale(), 1)
+		gender = "Male"
 	}
 
 	// {{titleFemale}}
 	if strings.Contains(name, "{{titleFemale}}") {
 		name = strings.Replace(name, "{{titleFemale}}", p.TitleFemale(), 1)
+		gender = "Female"
 	}
 
 	//{{firstNameFemale}}
 	if strings.Contains(name, "{{firstNameFemale}}") {
 		name = strings.Replace(name, "{{firstNameFemale}}", p.FirstNameFemale(), 1)
+		gender = "Female"
 	}
 
 	//{{lastName}}
@@ -179,5 +185,12 @@ func (p Person) Name() string {
 		name = strings.Replace(name, "{{suffix}}", p.Suffix(), 1)
 	}
 
+	p.gender = gender
+
 	return name
+}
+
+func (p *Person) Gender() string {
+	gender := p.gender
+	return gender
 }

--- a/person_test.go
+++ b/person_test.go
@@ -63,3 +63,9 @@ func TestName(t *testing.T) {
 	Expect(t, false, strings.Contains(name, "{{suffix}}"))
 	Expect(t, true, gender == "Male" || gender == "Female")
 }
+
+func TestGender(t *testing.T) {
+	p := New().Person()
+	gender := p.Gender()
+	Expect(t, true, gender == "Male" || gender == "Female")
+}

--- a/person_test.go
+++ b/person_test.go
@@ -69,3 +69,10 @@ func TestGender(t *testing.T) {
 	gender := p.Gender()
 	Expect(t, true, gender == "Male" || gender == "Female")
 }
+
+func TestNameAndGender(t *testing.T) {
+	p := New().Person()
+	name, gender := p.NameAndGender()
+	Expect(t, true, name != "")
+	Expect(t, true, gender == "Male" || gender == "Female")
+}

--- a/person_test.go
+++ b/person_test.go
@@ -53,6 +53,7 @@ func TestLastName(t *testing.T) {
 func TestName(t *testing.T) {
 	p := New().Person()
 	name := p.Name()
+	gender := p.Gender()
 	Expect(t, true, len(name) > 0)
 	Expect(t, false, strings.Contains(name, "{{titleMale}}"))
 	Expect(t, false, strings.Contains(name, "{{firstNameMale}}"))
@@ -60,4 +61,5 @@ func TestName(t *testing.T) {
 	Expect(t, false, strings.Contains(name, "{{firstNameFemale}}"))
 	Expect(t, false, strings.Contains(name, "{{lastName}}"))
 	Expect(t, false, strings.Contains(name, "{{suffix}}"))
+	Expect(t, true, gender == "Male" || gender == "Female")
 }


### PR DESCRIPTION
I imagine if I need gender as fake data but I want the gender still related to her/his name.
I think this code in this PR, not at the top of best practice

example usage
```golang
p := New().Person()
name := p.Name()
gender := p.Gender()
fmt.Println(name, gender)
```