### PR TITLE
Fixing conversion from int to string yields a string of one rune, not…

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -95,7 +95,7 @@ func (f Faker) Letter() string {
 }
 
 func (f Faker) RandomLetter() string {
-	return string(f.IntBetween(97, 122))
+	return fmt.Sprintf("%c",f.IntBetween(97, 122))
 }
 
 func (f Faker) RandomStringElement(s []string) string {
@@ -152,7 +152,7 @@ func (f Faker) Bothify(in string) (out string) {
 func (f Faker) Asciify(in string) (out string) {
 	for _, c := range strings.Split(in, "") {
 		if c == "*" {
-			c = string(f.IntBetween(97, 126))
+			c = fmt.Sprintf("%c",f.IntBetween(97, 126))
 		}
 
 		out = out + c


### PR DESCRIPTION
Fixing "conversion from int to string yields a string of one rune, not a string of digits" due to new Go versions (1.15)