### PR TITLE
#19: change comparison operator

### DIFF
--- a/time_test.go
+++ b/time_test.go
@@ -157,7 +157,7 @@ func TestYear(t *testing.T) {
 	tf := New().Time()
 
 	year := tf.Year()
-	Expect(t, true, year > 1970)
+	Expect(t, true, year >= 1970)
 	Expect(t, 4, len(strconv.Itoa(year)))
 }
 


### PR DESCRIPTION
## Description

Fixes: Issue #19 

The problem is at the comparison of `year > 1970`. The `Year()` function returns an `IntBetween(1970, time.Now().Year)` on [time.go](https://github.com/jaswdr/faker/blob/master/time.go#L136-L138) which makes it possible to return a `1970` year sometimes causing tests to fail randomly.
