### PR TITLE
Add/extension file

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -262,6 +262,11 @@ func (f Faker) Image() Image {
 	return Image{&f}
 }
 
+// File returns a fake File instance for Faker
+func (f Faker) File() File {
+	return File{&f}
+}
+
 // YouTube returns a fake YouTube instance for Faker
 func (f Faker) YouTube() YouTube {
 	return YouTube{&f}

--- a/file.go
+++ b/file.go
@@ -1,0 +1,25 @@
+package faker
+
+import "fmt"
+
+var (
+	extensions = []string{"ods", "xls", "xlsx", "csv", "ics", "vcf", "3dm", "3ds", "max", "bmp", "dds", "gif", "jpg", "jpeg", "png", "psd", "xcf", "tga", "thm", "tif", "tiff", "yuv", "ai", "eps", "ps", "svg", "dwg", "dxf", "gpx", "kml", "kmz", "webp", "3g2", "3gp", "aaf", "asf", "avchd", "avi", "drc", "flv", "m2v", "m4p", "m4v", "mkv", "mng", "mov", "mp2", "mp4", "mpe", "mpeg", "mpg", "mpv", "mxf", "nsv", "ogg", "ogv", "ogm", "qt", "rm", "rmvb", "roq", "srt", "svi", "vob", "webm", "wmv", "yuv", "aac", "aiff", "ape", "au", "flac", "gsm", "it", "m3u", "m4a", "mid", "mod", "mp3", "mpa", "pls", "ra", "s3m", "sid", "wav", "wma", "xm", "7z", "a", "apk", "ar", "bz2", "cab", "cpio", "deb", "dmg", "egg", "gz", "iso", "jar", "lha", "mar", "pea", "rar", "rpm", "s7z", "shar", "tar", "tbz2", "tgz", "tlz", "war", "whl", "xpi", "zip", "zipx", "xz", "pak", "exe", "msi", "bin", "command", "sh", "bat", "crx", "c", "cc", "class", "clj", "cpp", "cs", "cxx", "el", "go", "h", "java", "lua", "m", "m4", "php", "pl", "po", "py", "rb", "rs", "sh", "swift", "vb", "vcxproj", "xcodeproj", "xml", "diff", "patch", "html", "js", "html", "htm", "css", "js", "jsx", "less", "scss", "wasm", "php", "eot", "otf", "ttf", "woff", "woff2", "ppt", "odp", "doc", "docx", "ebook", "log", "md", "msg", "odt", "org", "pages", "pdf", "rtf", "rst", "tex", "txt", "wpd", "wps", "mobi", "epub", "azw1", "azw3", "azw4", "azw6", "azw", "cbr", "cbz"}
+)
+
+// File is a faker struct for File
+type File struct {
+	Faker *Faker
+}
+
+// Extension returns a fake Extension file
+func (f File) Extension() string {
+	return f.Faker.RandomStringElement(extensions)
+}
+
+// FileWithExtension returns a fake file name with extension
+func (f File) FileWithExtension() string {
+	extension := f.Faker.RandomStringElement(extensions)
+	text := f.Faker.Lorem().Word()
+
+	return fmt.Sprintf("%s.%s", text, extension)
+}

--- a/file.go
+++ b/file.go
@@ -16,8 +16,8 @@ func (f File) Extension() string {
 	return f.Faker.RandomStringElement(extensions)
 }
 
-// FileWithExtension returns a fake file name with extension
-func (f File) FileWithExtension() string {
+// FilenameWithExtension returns a fake file name with extension
+func (f File) FilenameWithExtension() string {
 	extension := f.Faker.RandomStringElement(extensions)
 	text := f.Faker.Lorem().Word()
 

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,16 @@
+package faker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtension(t *testing.T) {
+	p := New().File()
+	Expect(t, true, len(p.Extension()) > 2)
+}
+
+func TestFileWithExtension(t *testing.T) {
+	p := New().File()
+	Expect(t, true, len(strings.Split(p.FileWithExtension(), ".")) == 2)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -12,5 +12,5 @@ func TestExtension(t *testing.T) {
 
 func TestFileWithExtension(t *testing.T) {
 	p := New().File()
-	Expect(t, true, len(strings.Split(p.FileWithExtension(), ".")) == 2)
+	Expect(t, true, len(strings.Split(p.FilenameWithExtension(), ".")) == 2)
 }


### PR DESCRIPTION
**Description**

adding faker for file (extension)

usage
```
faker := faker.New().File()
ext := faker.Extension()
file := faker.FilenameWithExtension()

fmt.Println(ext, file)
```

**Are you trying to fix an existing issue?**

#13 

**Go Version**

```
go version go1.14.3 linux/amd64
```

**Go Tests**

```
=== RUN   TestCityPrefix
--- PASS: TestCityPrefix (0.00s)
=== RUN   TestSecondaryAddress
--- PASS: TestSecondaryAddress (0.00s)
=== RUN   TestState
--- PASS: TestState (0.00s)
=== RUN   TestStateAbbr
--- PASS: TestStateAbbr (0.00s)
=== RUN   TestCitySuffix
--- PASS: TestCitySuffix (0.00s)
=== RUN   TestStreetSuffix
--- PASS: TestStreetSuffix (0.00s)
=== RUN   TestBuildingNumber
--- PASS: TestBuildingNumber (0.00s)
=== RUN   TestCity
--- PASS: TestCity (0.00s)
=== RUN   TestStreetName
--- PASS: TestStreetName (0.00s)
=== RUN   TestStreetAddress
--- PASS: TestStreetAddress (0.00s)
=== RUN   TestPostCode
--- PASS: TestPostCode (0.00s)
=== RUN   TestAddress
--- PASS: TestAddress (0.00s)
=== RUN   TestCountry
--- PASS: TestCountry (0.00s)
=== RUN   TestLatitude
--- PASS: TestLatitude (0.00s)
=== RUN   TestLongitude
--- PASS: TestLongitude (0.00s)
=== RUN   TestBooleanBool
--- PASS: TestBooleanBool (0.00s)
=== RUN   TestBooleanBoolWithChance
--- PASS: TestBooleanBoolWithChance (0.00s)
=== RUN   TestBooleanInt
--- PASS: TestBooleanInt (0.00s)
=== RUN   TestBooleanString
--- PASS: TestBooleanString (0.00s)
=== RUN   TestHex
--- PASS: TestHex (0.00s)
=== RUN   TestRGB
--- PASS: TestRGB (0.00s)
=== RUN   TestRGBAsArray
--- PASS: TestRGBAsArray (0.00s)
=== RUN   TestCSS
--- PASS: TestCSS (0.00s)
=== RUN   TestSafeColorName
--- PASS: TestSafeColorName (0.00s)
=== RUN   TestColorName
--- PASS: TestColorName (0.00s)
=== RUN   TestCompanyCatchPhrase
--- PASS: TestCompanyCatchPhrase (0.00s)
=== RUN   TestCompanyBS
--- PASS: TestCompanyBS (0.00s)
=== RUN   TestCompanySuffix
--- PASS: TestCompanySuffix (0.00s)
=== RUN   TestCompanyName
--- PASS: TestCompanyName (0.00s)
=== RUN   TestCompanyJobTitle
--- PASS: TestCompanyJobTitle (0.00s)
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestNewWithSeed
--- PASS: TestNewWithSeed (0.00s)
=== RUN   TestRandomDigit
--- PASS: TestRandomDigit (0.00s)
=== RUN   TestRandomDigitNot
--- PASS: TestRandomDigitNot (0.00s)
=== RUN   TestRandomDigitNotNull
--- PASS: TestRandomDigitNotNull (0.00s)
=== RUN   TestRandomNumber
--- PASS: TestRandomNumber (0.00s)
=== RUN   TestInt
--- PASS: TestInt (0.00s)
=== RUN   TestInt64
--- PASS: TestInt64 (0.00s)
=== RUN   TestInt32
--- PASS: TestInt32 (0.00s)
=== RUN   TestIntBetween
--- PASS: TestIntBetween (0.00s)
=== RUN   TestRandomFloat
--- PASS: TestRandomFloat (0.00s)
=== RUN   TestLetter
--- PASS: TestLetter (0.00s)
=== RUN   TestRandomLetter
--- PASS: TestRandomLetter (0.00s)
=== RUN   TestRandomIntElement
--- PASS: TestRandomIntElement (0.00s)
=== RUN   TestShuffleString
--- PASS: TestShuffleString (0.00s)
=== RUN   TestNumerify
--- PASS: TestNumerify (0.00s)
=== RUN   TestLexify
--- PASS: TestLexify (0.00s)
=== RUN   TestBothify
--- PASS: TestBothify (0.00s)
=== RUN   TestAsciify
--- PASS: TestAsciify (0.00s)
=== RUN   TestBool
--- PASS: TestBool (0.00s)
=== RUN   TestBoolWithChance
--- PASS: TestBoolWithChance (0.00s)
=== RUN   TestExtension
--- PASS: TestExtension (0.00s)
=== RUN   TestFileWithExtension
--- PASS: TestFileWithExtension (0.00s)
=== RUN   TestImage
--- PASS: TestImage (0.00s)
=== RUN   TestUser
--- PASS: TestUser (0.00s)
=== RUN   TestDomain
--- PASS: TestDomain (0.00s)
=== RUN   TestEmail
--- PASS: TestEmail (0.00s)
=== RUN   TestFreeEmail
--- PASS: TestFreeEmail (0.00s)
=== RUN   TestSafeEmail
--- PASS: TestSafeEmail (0.00s)
=== RUN   TestCompanyEmail
--- PASS: TestCompanyEmail (0.00s)
=== RUN   TestPassword
--- PASS: TestPassword (0.00s)
=== RUN   TestTLD
--- PASS: TestTLD (0.00s)
=== RUN   TestSlug
--- PASS: TestSlug (0.00s)
=== RUN   TestURL
--- PASS: TestURL (0.00s)
=== RUN   TestIpv4
--- PASS: TestIpv4 (0.00s)
=== RUN   TestLocalIpv4
--- PASS: TestLocalIpv4 (0.00s)
=== RUN   TestIpv6
--- PASS: TestIpv6 (0.00s)
=== RUN   TestMacAddress
--- PASS: TestMacAddress (0.00s)
=== RUN   TestHTTPMethod
--- PASS: TestHTTPMethod (0.00s)
=== RUN   TestQuery
--- PASS: TestQuery (0.00s)
=== RUN   TestLorem
--- PASS: TestLorem (0.00s)
=== RUN   TestWord
--- PASS: TestWord (0.00s)
=== RUN   TestWords
--- PASS: TestWords (0.00s)
=== RUN   TestSentence
--- PASS: TestSentence (0.00s)
=== RUN   TestSentences
--- PASS: TestSentences (0.00s)
=== RUN   TestParagraph
--- PASS: TestParagraph (0.00s)
=== RUN   TestParagraphs
--- PASS: TestParagraphs (0.00s)
=== RUN   TestText
--- PASS: TestText (0.00s)
=== RUN   TestBytes
--- PASS: TestBytes (0.00s)
=== RUN   TestMimeType
--- PASS: TestMimeType (0.00s)
=== RUN   TestCreditCardType
--- PASS: TestCreditCardType (0.00s)
=== RUN   TestCreditCardNumber
--- PASS: TestCreditCardNumber (0.00s)
=== RUN   TestCreditCardExpirationDateString
--- PASS: TestCreditCardExpirationDateString (0.00s)
=== RUN   TestTitleMale
--- PASS: TestTitleMale (0.00s)
=== RUN   TestTitleFemale
--- PASS: TestTitleFemale (0.00s)
=== RUN   TestTitle
--- PASS: TestTitle (0.00s)
=== RUN   TestSuffix
--- PASS: TestSuffix (0.00s)
=== RUN   TestFirstNameMale
--- PASS: TestFirstNameMale (0.00s)
=== RUN   TestFirstNameFemale
--- PASS: TestFirstNameFemale (0.00s)
=== RUN   TestFirstName
--- PASS: TestFirstName (0.00s)
=== RUN   TestLastName
--- PASS: TestLastName (0.00s)
=== RUN   TestName
--- PASS: TestName (0.00s)
=== RUN   TestAreaCode
--- PASS: TestAreaCode (0.00s)
=== RUN   TestExchangeCode
--- PASS: TestExchangeCode (0.00s)
=== RUN   TestNumber
--- PASS: TestNumber (0.00s)
=== RUN   TestTollFreeAreaCode
--- PASS: TestTollFreeAreaCode (0.00s)
=== RUN   TestTollFreeNumber
--- PASS: TestTollFreeNumber (0.00s)
=== RUN   TestE164Number
--- PASS: TestE164Number (0.00s)
=== RUN   TestTimeUnix
--- PASS: TestTimeUnix (0.00s)
=== RUN   TestTimeTime
--- PASS: TestTimeTime (0.00s)
=== RUN   TestISO8601
--- PASS: TestISO8601 (0.00s)
=== RUN   TestANSIC
--- PASS: TestANSIC (0.00s)
=== RUN   TestUnixDate
--- PASS: TestUnixDate (0.00s)
=== RUN   TestRubyDate
--- PASS: TestRubyDate (0.00s)
=== RUN   TestRFC822
--- PASS: TestRFC822 (0.00s)
=== RUN   TestRFC822Z
--- PASS: TestRFC822Z (0.00s)
=== RUN   TestRFC850
--- PASS: TestRFC850 (0.00s)
=== RUN   TestRFC1123
--- PASS: TestRFC1123 (0.00s)
=== RUN   TestRFC1123Z
--- PASS: TestRFC1123Z (0.00s)
=== RUN   TestRFC3339
--- PASS: TestRFC3339 (0.00s)
=== RUN   TestRFC3339Nano
--- PASS: TestRFC3339Nano (0.00s)
=== RUN   TestKitchen
--- PASS: TestKitchen (0.00s)
=== RUN   TestTimeBetween
--- PASS: TestTimeBetween (0.00s)
=== RUN   TestAmPm
--- PASS: TestAmPm (0.00s)
=== RUN   TestDayOfMonth
--- PASS: TestDayOfMonth (0.00s)
=== RUN   TestDayOfWeek
--- PASS: TestDayOfWeek (0.00s)
=== RUN   TestMonth
--- PASS: TestMonth (0.00s)
=== RUN   TestMonthName
--- PASS: TestMonthName (0.00s)
=== RUN   TestYear
--- PASS: TestYear (0.00s)
=== RUN   TestCentury
--- PASS: TestCentury (0.00s)
=== RUN   TestTimezone
--- PASS: TestTimezone (0.00s)
=== RUN   TestInternetExplorer
--- PASS: TestInternetExplorer (0.00s)
=== RUN   TestOpera
--- PASS: TestOpera (0.00s)
=== RUN   TestSafari
--- PASS: TestSafari (0.00s)
=== RUN   TestFirefox
--- PASS: TestFirefox (0.00s)
=== RUN   TestChrome
--- PASS: TestChrome (0.00s)
=== RUN   TestUserAgent
--- PASS: TestUserAgent (0.00s)
=== RUN   TestUUIDv4
--- PASS: TestUUIDv4 (0.00s)
=== RUN   TestUUIDV4UniqueInSequence
--- PASS: TestUUIDV4UniqueInSequence (0.00s)
=== RUN   TestGenerateVideoID
--- PASS: TestGenerateVideoID (0.00s)
=== RUN   TestGenerateFullURL
--- PASS: TestGenerateFullURL (0.00s)
=== RUN   TestGenerateShareURL
--- PASS: TestGenerateShareURL (0.00s)
=== RUN   TestGenerateEmbededURL
--- PASS: TestGenerateEmbededURL (0.00s)
PASS
ok      github.com/jaswdr/faker 0.007s
```
