### PR TITLE
31: fix IntBetween generator

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -89,7 +89,7 @@ func (f Faker) IntBetween(min, max int) int {
 		return min
 	}
 
-	return min + (f.Generator.Int() % diff)
+	return min + f.Generator.Intn(diff+1)
 }
 
 // Int64Between returns a fake Int64 between a given minimum and maximum values for Faker


### PR DESCRIPTION
**Description**

Fixes issue #31. While this is a sample fix, it doesn't fix failing tests yet.

**Are you trying to fix an existing issue?**

https://github.com/jaswdr/faker/issues/31

**Go Version**

```
$ go version
go version go1.15.2 linux/amd64
```

**Go Tests**

```
$ go test -v
# replace this line with the output
```
