### PR TITLE
person.go: 100% test coverage

### DIFF
--- a/internal/test/fake_source.go
+++ b/internal/test/fake_source.go
@@ -1,0 +1,26 @@
+package test
+
+// FakeSource implements the rand.Source interface. This is useful for when we
+// want to supply dummy/predictable values to test specific scenarios that depend
+// on rand.Rand.
+type FakeSource struct {
+	seed int64
+}
+
+// NewFakeSource returns a new instance of FakeSource. FakeSource does not
+// generates random numbers, so the passed in seed number is the returned "random"
+// number.
+func NewFakeSource(seed int64) *FakeSource {
+	return &FakeSource{seed: seed}
+}
+
+// Seed sets the internal int to the passed in seed value. This will be the returned
+// value when using FakeSource.Int63().
+func (s *FakeSource) Seed(seed int64) {
+	s.seed = seed
+}
+
+// Int63 returns the dummy seed value.
+func (s *FakeSource) Int63() int64 {
+	return s.seed
+}

--- a/internal/test/fake_source_test.go
+++ b/internal/test/fake_source_test.go
@@ -1,0 +1,17 @@
+package test
+
+import "testing"
+
+func TestFakeGenerator(t *testing.T) {
+	s := NewFakeSource(100)
+
+	if n := s.Int63(); n != 100 {
+		t.Errorf("expected 100 but got %d", n)
+	}
+
+	s.Seed(200)
+
+	if n := s.Int63(); n != 200 {
+		t.Errorf("expected 200 but got %d", n)
+	}
+}

--- a/person.go
+++ b/person.go
@@ -134,7 +134,7 @@ func (p Person) GenderFemale() string {
 
 // Title returns a fake title for Person
 func (p Person) Title() string {
-	if p.Faker.IntBetween(0, 1) == 0 {
+	if p.Faker.IntBetween(0, 2) == 0 {
 		return p.TitleMale()
 	}
 
@@ -168,7 +168,7 @@ func (p Person) LastName() string {
 // Name returns a fake name for Person
 func (p Person) Name() string {
 	formats := append(maleNameFormats, femaleNameFormats...)
-	name := formats[p.Faker.IntBetween(0, len(formats)-1)]
+	name := formats[p.Faker.IntBetween(0, len(formats))]
 
 	// {{titleMale}}
 	if strings.Contains(name, "{{titleMale}}") {

--- a/person_test.go
+++ b/person_test.go
@@ -3,6 +3,8 @@ package faker
 import (
 	"strings"
 	"testing"
+
+	"github.com/jaswdr/faker/internal/test"
 )
 
 func TestTitleMale(t *testing.T) {
@@ -16,8 +18,22 @@ func TestTitleFemale(t *testing.T) {
 }
 
 func TestTitle(t *testing.T) {
-	p := New().Person()
-	Expect(t, 3, len(p.Title()))
+	// Test Title Male
+	s := test.NewFakeSource(0)
+	f := NewWithSeed(s)
+	maleTitle := f.Person().Title()
+
+	Expect(t, 3, len(maleTitle))
+
+	// Test Title Female
+	s.Seed(1)
+	femaleTitle := f.Person().Title()
+
+	Expect(t, 3, len(femaleTitle))
+
+	if maleTitle == femaleTitle {
+		t.Errorf("expected male title '%s' to be different from female title '%s'", maleTitle, femaleTitle)
+	}
 }
 
 func TestSuffix(t *testing.T) {
@@ -51,8 +67,25 @@ func TestLastName(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	p := New().Person()
-	name := p.Name()
+	// Set fake generator int to 6 to grab this maleNameFormat:
+	// "{{titleMale}} {{firstNameMale}} {{lastName}} {{suffix}}"
+	s := test.NewFakeSource(6)
+	f := NewWithSeed(s)
+	name := f.Person().Name()
+
+	Expect(t, true, len(name) > 0)
+	Expect(t, false, strings.Contains(name, "{{titleMale}}"))
+	Expect(t, false, strings.Contains(name, "{{firstNameMale}}"))
+	Expect(t, false, strings.Contains(name, "{{titleFemale}}"))
+	Expect(t, false, strings.Contains(name, "{{firstNameFemale}}"))
+	Expect(t, false, strings.Contains(name, "{{lastName}}"))
+	Expect(t, false, strings.Contains(name, "{{suffix}}"))
+
+	// Set int to 13 to grab this femaleNameFormat:
+	// "{{titleFemale}} {{firstNameFemale}} {{lastName}} {{suffix}}"
+	s.Seed(13)
+	name = f.Person().Name()
+
 	Expect(t, true, len(name) > 0)
 	Expect(t, false, strings.Contains(name, "{{titleMale}}"))
 	Expect(t, false, strings.Contains(name, "{{firstNameMale}}"))
@@ -79,8 +112,17 @@ func TestGenderFemale(t *testing.T) {
 }
 
 func TestNameAndGender(t *testing.T) {
-	p := New().Person()
-	name, gender := p.NameAndGender()
+	// Test Name and Gender Female.
+	s := test.NewFakeSource(0)
+	f := NewWithSeed(s)
+	name, gender := f.Person().NameAndGender()
+
 	Expect(t, true, name != "")
-	Expect(t, true, gender == "Male" || gender == "Female")
+	Expect(t, true, gender == "Female")
+
+	// Test Name and Gender Male.
+	s.Seed(51)
+	name, gender = f.Person().NameAndGender()
+	Expect(t, true, name != "")
+	Expect(t, true, gender == "Male")
 }


### PR DESCRIPTION
**Description**

100% test coverage for `person.go`.

**Are you trying to fix an existing issue?**

Includes partial fixes for #28. 

**Go Version**

```
$ go version
go version go1.15.2 linux/amd64
```

**Go Tests**

```
$ go test -v
=== RUN   TestCityPrefix
--- PASS: TestCityPrefix (0.00s)
=== RUN   TestSecondaryAddress
--- PASS: TestSecondaryAddress (0.00s)
=== RUN   TestState
--- PASS: TestState (0.00s)
=== RUN   TestStateAbbr
--- PASS: TestStateAbbr (0.00s)
=== RUN   TestCitySuffix
--- PASS: TestCitySuffix (0.00s)
=== RUN   TestStreetSuffix
--- PASS: TestStreetSuffix (0.00s)
=== RUN   TestBuildingNumber
--- PASS: TestBuildingNumber (0.00s)
=== RUN   TestCity
--- PASS: TestCity (0.00s)
=== RUN   TestStreetName
--- PASS: TestStreetName (0.00s)
=== RUN   TestStreetAddress
--- PASS: TestStreetAddress (0.00s)
=== RUN   TestPostCode
--- PASS: TestPostCode (0.00s)
=== RUN   TestAddress
--- PASS: TestAddress (0.00s)
=== RUN   TestCountry
--- PASS: TestCountry (0.00s)
=== RUN   TestLatitude
--- PASS: TestLatitude (0.00s)
=== RUN   TestLongitude
--- PASS: TestLongitude (0.00s)
=== RUN   TestBooleanBool
--- PASS: TestBooleanBool (0.00s)
=== RUN   TestBooleanBoolWithChance
--- PASS: TestBooleanBoolWithChance (0.00s)
=== RUN   TestBooleanInt
--- PASS: TestBooleanInt (0.00s)
=== RUN   TestBooleanString
--- PASS: TestBooleanString (0.00s)
=== RUN   TestHex
--- PASS: TestHex (0.00s)
=== RUN   TestRGB
--- PASS: TestRGB (0.00s)
=== RUN   TestRGBAsArray
--- PASS: TestRGBAsArray (0.00s)
=== RUN   TestCSS
--- PASS: TestCSS (0.00s)
=== RUN   TestSafeColorName
--- PASS: TestSafeColorName (0.00s)
=== RUN   TestColorName
--- PASS: TestColorName (0.00s)
=== RUN   TestCompanyCatchPhrase
--- PASS: TestCompanyCatchPhrase (0.00s)
=== RUN   TestCompanyBS
--- PASS: TestCompanyBS (0.00s)
=== RUN   TestCompanySuffix
--- PASS: TestCompanySuffix (0.00s)
=== RUN   TestCompanyName
--- PASS: TestCompanyName (0.00s)
=== RUN   TestCompanyJobTitle
--- PASS: TestCompanyJobTitle (0.00s)
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestNewWithSeed
--- PASS: TestNewWithSeed (0.00s)
=== RUN   TestRandomDigit
--- PASS: TestRandomDigit (0.00s)
=== RUN   TestRandomDigitNot
--- PASS: TestRandomDigitNot (0.00s)
=== RUN   TestRandomDigitNotNull
--- PASS: TestRandomDigitNotNull (0.00s)
=== RUN   TestRandomNumber
--- PASS: TestRandomNumber (0.00s)
=== RUN   TestInt
--- PASS: TestInt (0.00s)
=== RUN   TestInt64
--- PASS: TestInt64 (0.00s)
=== RUN   TestInt32
--- PASS: TestInt32 (0.00s)
=== RUN   TestIntBetween
--- PASS: TestIntBetween (0.00s)
=== RUN   TestRandomFloat
--- PASS: TestRandomFloat (0.00s)
=== RUN   TestLetter
--- PASS: TestLetter (0.00s)
=== RUN   TestRandomLetter
--- PASS: TestRandomLetter (0.00s)
=== RUN   TestRandomIntElement
--- PASS: TestRandomIntElement (0.00s)
=== RUN   TestShuffleString
--- PASS: TestShuffleString (0.00s)
=== RUN   TestNumerify
--- PASS: TestNumerify (0.00s)
=== RUN   TestLexify
--- PASS: TestLexify (0.00s)
=== RUN   TestBothify
--- PASS: TestBothify (0.00s)
=== RUN   TestAsciify
--- PASS: TestAsciify (0.00s)
=== RUN   TestBool
--- PASS: TestBool (0.00s)
=== RUN   TestBoolWithChance
--- PASS: TestBoolWithChance (0.00s)
=== RUN   TestExtension
--- PASS: TestExtension (0.00s)
=== RUN   TestFileWithExtension
--- PASS: TestFileWithExtension (0.00s)
=== RUN   TestImage
--- PASS: TestImage (0.00s)
=== RUN   TestUser
--- PASS: TestUser (0.00s)
=== RUN   TestDomain
--- PASS: TestDomain (0.00s)
=== RUN   TestEmail
--- PASS: TestEmail (0.00s)
=== RUN   TestFreeEmail
--- PASS: TestFreeEmail (0.00s)
=== RUN   TestSafeEmail
--- PASS: TestSafeEmail (0.00s)
=== RUN   TestCompanyEmail
--- PASS: TestCompanyEmail (0.00s)
=== RUN   TestPassword
--- PASS: TestPassword (0.00s)
=== RUN   TestTLD
--- PASS: TestTLD (0.00s)
=== RUN   TestSlug
--- PASS: TestSlug (0.00s)
=== RUN   TestURL
--- PASS: TestURL (0.00s)
=== RUN   TestIpv4
--- PASS: TestIpv4 (0.00s)
=== RUN   TestLocalIpv4
--- PASS: TestLocalIpv4 (0.00s)
=== RUN   TestIpv6
--- PASS: TestIpv6 (0.00s)
=== RUN   TestMacAddress
--- PASS: TestMacAddress (0.00s)
=== RUN   TestHTTPMethod
--- PASS: TestHTTPMethod (0.00s)
=== RUN   TestQuery
--- PASS: TestQuery (0.00s)
=== RUN   TestLorem
--- PASS: TestLorem (0.00s)
=== RUN   TestWord
--- PASS: TestWord (0.00s)
=== RUN   TestWords
--- PASS: TestWords (0.00s)
=== RUN   TestSentence
--- PASS: TestSentence (0.00s)
=== RUN   TestSentences
--- PASS: TestSentences (0.00s)
=== RUN   TestParagraph
--- PASS: TestParagraph (0.00s)
=== RUN   TestParagraphs
--- PASS: TestParagraphs (0.00s)
=== RUN   TestText
--- PASS: TestText (0.00s)
=== RUN   TestBytes
--- PASS: TestBytes (0.00s)
=== RUN   TestMimeType
--- PASS: TestMimeType (0.00s)
=== RUN   TestCreditCardType
--- PASS: TestCreditCardType (0.00s)
=== RUN   TestCreditCardNumber
--- PASS: TestCreditCardNumber (0.00s)
=== RUN   TestCreditCardExpirationDateString
--- PASS: TestCreditCardExpirationDateString (0.00s)
=== RUN   TestTitleMale
--- PASS: TestTitleMale (0.00s)
=== RUN   TestTitleFemale
--- PASS: TestTitleFemale (0.00s)
=== RUN   TestTitle
--- PASS: TestTitle (0.00s)
=== RUN   TestSuffix
--- PASS: TestSuffix (0.00s)
=== RUN   TestFirstNameMale
--- PASS: TestFirstNameMale (0.00s)
=== RUN   TestFirstNameFemale
--- PASS: TestFirstNameFemale (0.00s)
=== RUN   TestFirstName
--- PASS: TestFirstName (0.00s)
=== RUN   TestLastName
--- PASS: TestLastName (0.00s)
=== RUN   TestName
--- PASS: TestName (0.00s)
=== RUN   TestGender
--- PASS: TestGender (0.00s)
=== RUN   TestGenderMale
--- PASS: TestGenderMale (0.00s)
=== RUN   TestGenderFemale
--- PASS: TestGenderFemale (0.00s)
=== RUN   TestNameAndGender
--- PASS: TestNameAndGender (0.00s)
=== RUN   TestAreaCode
--- PASS: TestAreaCode (0.00s)
=== RUN   TestExchangeCode
--- PASS: TestExchangeCode (0.00s)
=== RUN   TestNumber
--- PASS: TestNumber (0.00s)
=== RUN   TestTollFreeAreaCode
--- PASS: TestTollFreeAreaCode (0.00s)
=== RUN   TestTollFreeNumber
--- PASS: TestTollFreeNumber (0.00s)
=== RUN   TestE164Number
--- PASS: TestE164Number (0.00s)
=== RUN   TestTimeUnix
--- PASS: TestTimeUnix (0.00s)
=== RUN   TestTimeTime
--- PASS: TestTimeTime (0.00s)
=== RUN   TestISO8601
--- PASS: TestISO8601 (0.00s)
=== RUN   TestANSIC
--- PASS: TestANSIC (0.00s)
=== RUN   TestUnixDate
--- PASS: TestUnixDate (0.00s)
=== RUN   TestRubyDate
--- PASS: TestRubyDate (0.00s)
=== RUN   TestRFC822
--- PASS: TestRFC822 (0.00s)
=== RUN   TestRFC822Z
--- PASS: TestRFC822Z (0.00s)
=== RUN   TestRFC850
--- PASS: TestRFC850 (0.00s)
=== RUN   TestRFC1123
--- PASS: TestRFC1123 (0.00s)
=== RUN   TestRFC1123Z
--- PASS: TestRFC1123Z (0.00s)
=== RUN   TestRFC3339
--- PASS: TestRFC3339 (0.00s)
=== RUN   TestRFC3339Nano
--- PASS: TestRFC3339Nano (0.00s)
=== RUN   TestKitchen
--- PASS: TestKitchen (0.00s)
=== RUN   TestTimeBetween
--- PASS: TestTimeBetween (0.00s)
=== RUN   TestAmPm
--- PASS: TestAmPm (0.00s)
=== RUN   TestDayOfMonth
--- PASS: TestDayOfMonth (0.00s)
=== RUN   TestDayOfWeek
--- PASS: TestDayOfWeek (0.00s)
=== RUN   TestMonth
--- PASS: TestMonth (0.00s)
=== RUN   TestMonthName
--- PASS: TestMonthName (0.00s)
=== RUN   TestYear
--- PASS: TestYear (0.00s)
=== RUN   TestCentury
--- PASS: TestCentury (0.00s)
=== RUN   TestTimezone
--- PASS: TestTimezone (0.00s)
=== RUN   TestInternetExplorer
--- PASS: TestInternetExplorer (0.00s)
=== RUN   TestOpera
--- PASS: TestOpera (0.00s)
=== RUN   TestSafari
--- PASS: TestSafari (0.00s)
=== RUN   TestFirefox
--- PASS: TestFirefox (0.00s)
=== RUN   TestChrome
--- PASS: TestChrome (0.00s)
=== RUN   TestUserAgent
--- PASS: TestUserAgent (0.00s)
=== RUN   TestUUIDv4
--- PASS: TestUUIDv4 (0.00s)
=== RUN   TestUUIDV4UniqueInSequence
--- PASS: TestUUIDV4UniqueInSequence (0.00s)
=== RUN   TestGenerateVideoID
--- PASS: TestGenerateVideoID (0.00s)
=== RUN   TestGenerateFullURL
--- PASS: TestGenerateFullURL (0.00s)
=== RUN   TestGenerateShareURL
--- PASS: TestGenerateShareURL (0.00s)
=== RUN   TestGenerateEmbededURL
--- PASS: TestGenerateEmbededURL (0.00s)
PASS
ok  	github.com/jaswdr/faker	0.013s
=== RUN   TestFakeGenerator
--- PASS: TestFakeGenerator (0.00s)
PASS
ok  	github.com/jaswdr/faker/internal/test	(cached)
```
