### PR TITLE
Fixed bug where Int() was generating only max values

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -86,9 +86,8 @@ func (f Faker) Float64(maxDecimals, min, max int) float64 {
 
 // Int returns a fake Int number for Faker
 func (f Faker) Int() int {
-	maxU := ^uint(0) >> 1
-	max := int(maxU)
-	min := -max - 2
+	max := int(^uint(0)>>1) - 1
+	min := 0
 	return f.IntBetween(min, max)
 }
 


### PR DESCRIPTION
**Description**

Fixing `Int()` to generate int values different from max(int), noticed by @Hedgehogues in #47

**Are you trying to fix an existing issue?**

The current implementation of Int() was generating only max values, making that any generator that depends from it (like struct.go) also was affected, this PR fix this behavior.

**Go Version**

```
$ go version
go version devel go1.17-053fe2f Sat May 1 19:17:47 2021 +0000 linux/amd64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker 0.011s
```
