### PR TITLE
Adding ProfileImage generator to generate profile pictures

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -439,6 +439,11 @@ func (f Faker) LoremFlickr() LoremFlickr {
 	return LoremFlickr{&f}
 }
 
+// ProfileImage returns a fake ProfileImage instance for Faker
+func (f Faker) ProfileImage() ProfileImage {
+	return ProfileImage{&f}
+}
+
 // New returns a new instance of Faker instance with a random seed
 func New() (f Faker) {
 	seed := rand.NewSource(time.Now().Unix())

--- a/lorem_flickr.go
+++ b/lorem_flickr.go
@@ -9,17 +9,17 @@ import (
 	"strconv"
 )
 
-const BASE_URL = "https://loremflickr.com"
+const LOREM_FLICKR_BASE_URL = "https://loremflickr.com"
 
 // LoremFlickr is a faker struct for LoremFlickr
 type LoremFlickr struct {
 	faker *Faker
 }
 
-// Image generates a *os.File with a random image using the loremflickre.com service
+// Image generates a *os.File with a random image using the loremflickr.com service
 func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) *os.File {
 
-	url := BASE_URL
+	url := LOREM_FLICKR_BASE_URL
 
 	switch prefix {
 	case "g":

--- a/lorem_flickr_test.go
+++ b/lorem_flickr_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestImageLorem(t *testing.T) {
+func TestLoremFlickrImage(t *testing.T) {
 	f := New()
 	value := f.LoremFlickr().Image(300, 200, []string{}, "", false)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")

--- a/person.go
+++ b/person.go
@@ -2,6 +2,7 @@ package faker
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -245,4 +246,9 @@ func (p Person) Contact() ContactInfo {
 		Phone: p.Faker.Phone().Number(),
 		Email: p.Faker.Internet().Email(),
 	}
+}
+
+// Image return the person profile image
+func (p Person) Image() *os.File {
+	return p.Faker.ProfileImage().Image()
 }

--- a/person_test.go
+++ b/person_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -96,4 +97,11 @@ func TestContact(t *testing.T) {
 	contact := p.Contact()
 	Expect(t, true, len(contact.Phone) > 0)
 	Expect(t, true, len(contact.Email) > 0)
+}
+
+func TestPersonImage(t *testing.T) {
+	p := New().Person()
+	image := p.Image()
+	Expect(t, fmt.Sprintf("%T", image), "*os.File")
+	Expect(t, strings.HasSuffix(image.Name(), ".jfif"), true, image.Name())
 }

--- a/profile_image.go
+++ b/profile_image.go
@@ -1,0 +1,34 @@
+package faker
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+const PROFILE_IMAGE_BASE_URL = "https://thispersondoesnotexist.com/image"
+
+// ProfileImage  is a faker struct for ProfileImage
+type ProfileImage struct {
+	faker *Faker
+}
+
+// Image generates a *os.File with a random profile image using the thispersondoesnotexist.com service
+func (pi ProfileImage) Image() *os.File {
+	resp, err := http.Get(PROFILE_IMAGE_BASE_URL)
+	if err != nil {
+		log.Println("Error while requesting", PROFILE_IMAGE_BASE_URL, ":", err)
+	}
+
+	defer resp.Body.Close()
+
+	f, err := ioutil.TempFile(os.TempDir(), "profil-picture-img-*.jfif")
+	if err != nil {
+		panic(err)
+	}
+
+	io.Copy(f, resp.Body)
+	return f
+}

--- a/profile_image_test.go
+++ b/profile_image_test.go
@@ -1,0 +1,14 @@
+package faker
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProfileImage(t *testing.T) {
+	f := New()
+	value := f.ProfileImage().Image()
+	Expect(t, fmt.Sprintf("%T", value), "*os.File")
+	Expect(t, strings.HasSuffix(value.Name(), ".jfif"), true, value.Name())
+}


### PR DESCRIPTION
**Description**

1. Adding ProfileImage generator to generate profile pictures using the remote service https://thispersondoesnotexist.com/.
1. Added `Image()` method to Person, make it possible to use `faker.Person().Image()` to generate a profile picture 
1. Fixed also some conflicts with the LoremFlickr generator.

**Are you trying to fix an existing issue?**

Don't apply

**Go Version**

```
$ go version
go version devel go1.17-053fe2f Sat May 1 19:17:47 2021 +0000 linux/amd64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker 0.695s
```
