### PR TITLE
Fixed E164Number to generate a phone number that doesn't start with 0

### DIFF
--- a/phone.go
+++ b/phone.go
@@ -112,5 +112,9 @@ func (p Phone) ToolFreeNumber() string {
 
 // E164Number returns a fake E164 phone number for Phone
 func (p Phone) E164Number() string {
-	return p.Faker.Numerify("+###########")
+	// Excluding 0 since it cannot be any country code in E164
+	firstDigit := p.Faker.IntBetween(1, 9)
+	randomDigits := p.Faker.Numerify("##########")
+
+	return fmt.Sprintf("+%d%s", firstDigit, randomDigits)
 }


### PR DESCRIPTION
**Description**

Changed E164Number function to exclude 0 as a first digit of a number since it's an invalid country code.

**Are you trying to fix an existing issue?**

[E164Number generates invalid E164 phone number](https://github.com/jaswdr/faker/issues/59)

**Go Version**

```
$ go version
go version go1.15.2 linux/amd64
```

**Go Tests**

```
$ go test
PASS
ok  	github.com/jaswdr/faker	1.193s
```
