### PR TITLE
Adding retry logic for methods that do HTTP requests

### DIFF
--- a/lorem_flickr.go
+++ b/lorem_flickr.go
@@ -4,12 +4,11 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 )
 
-const LOREM_FLICKR_BASE_URL = "https://loremflickr.com"
+const lorem_flickr_base_url = "https://loremflickr.com"
 
 // LoremFlickr is a faker struct for LoremFlickr
 type LoremFlickr struct {
@@ -19,7 +18,7 @@ type LoremFlickr struct {
 // Image generates a *os.File with a random image using the loremflickr.com service
 func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) *os.File {
 
-	url := LOREM_FLICKR_BASE_URL
+	url := lorem_flickr_base_url
 
 	switch prefix {
 	case "g":
@@ -49,11 +48,12 @@ func (lf LoremFlickr) Image(width, height int, categories []string, prefix strin
 		}
 	}
 
-	resp, err := http.Get(url)
+	resp, err := get(url)
+	defer resp.Body.Close()
+
 	if err != nil {
 		log.Println("Error while requesting", url, ":", err)
 	}
-	defer resp.Body.Close()
 
 	f, err := ioutil.TempFile(os.TempDir(), "loremflickr-img-*.jpg")
 	if err != nil {

--- a/profile_image.go
+++ b/profile_image.go
@@ -4,11 +4,10 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 )
 
-const PROFILE_IMAGE_BASE_URL = "https://thispersondoesnotexist.com/image"
+const profile_image_base_url = "https://thispersondoesnotexist.com/image"
 
 // ProfileImage  is a faker struct for ProfileImage
 type ProfileImage struct {
@@ -17,12 +16,12 @@ type ProfileImage struct {
 
 // Image generates a *os.File with a random profile image using the thispersondoesnotexist.com service
 func (pi ProfileImage) Image() *os.File {
-	resp, err := http.Get(PROFILE_IMAGE_BASE_URL)
-	if err != nil {
-		log.Println("Error while requesting", PROFILE_IMAGE_BASE_URL, ":", err)
-	}
-
+	resp, err := get(profile_image_base_url)
 	defer resp.Body.Close()
+
+	if err != nil {
+		log.Println("Error while requesting", profile_image_base_url, ":", err)
+	}
 
 	f, err := ioutil.TempFile(os.TempDir(), "profil-picture-img-*.jfif")
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,20 @@
+package faker
+
+import (
+	"net/http"
+)
+
+const (
+	max_retries = 7
+)
+
+func get(url string) (resp *http.Response, err error) {
+	for i := 0; i < max_retries; i++ {
+		resp, err = http.Get(url)
+		if err == nil {
+			return resp, err
+		}
+	}
+
+	return resp, err
+}


### PR DESCRIPTION
**Description**

We are seeing some timeout transient errors in tests that do http requests to remote services, this PR adds a retry logic by retrying the call 7 times before giving up.

**Are you trying to fix an existing issue?**

Fixing possible transient failures when calling remote services.

**Go Version**

```
$ go version
go version go1.14.5 darwin/amd64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker 1.387s
```
