### PR TITLE
Fix variable names

### DIFF
--- a/lorem_flickr.go
+++ b/lorem_flickr.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-const loremFlickrBaseUrl = "https://loremflickr.com"
+const loremFlickrBaseURL = "https://loremflickr.com"
 
 // LoremFlickr is a faker struct for LoremFlickr
 type LoremFlickr struct {
@@ -18,7 +18,7 @@ type LoremFlickr struct {
 // Image generates a *os.File with a random image using the loremflickr.com service
 func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) *os.File {
 
-	url := loremFlickrBaseUrl
+	url := loremFlickrBaseURL
 
 	switch prefix {
 	case "g":

--- a/profile_image.go
+++ b/profile_image.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const profileImageBaseUrl = "https://thispersondoesnotexist.com/image"
+const profileImageBaseURL = "https://thispersondoesnotexist.com/image"
 
 // ProfileImage  is a faker struct for ProfileImage
 type ProfileImage struct {
@@ -16,11 +16,11 @@ type ProfileImage struct {
 
 // Image generates a *os.File with a random profile image using the thispersondoesnotexist.com service
 func (pi ProfileImage) Image() *os.File {
-	resp, err := get(profileImageBaseUrl)
+	resp, err := get(profileImageBaseURL)
 	defer resp.Body.Close()
 
 	if err != nil {
-		log.Println("Error while requesting", profileImageBaseUrl, ":", err)
+		log.Println("Error while requesting", profileImageBaseURL, ":", err)
 	}
 
 	f, err := ioutil.TempFile(os.TempDir(), "profil-picture-img-*.jfif")


### PR DESCRIPTION
**Description**

Change `Url` to `URL` in variable names.

**Are you trying to fix an existing issue?**

Minor fixes to variables names.

**Go Version**

```
$ go version
# replace this line with the output
```

**Go Tests**
go version go1.14.5 darwin/amd64
```
$ go test
PASS
ok      github.com/jaswdr/faker 1.972s
```
