### PR TITLE
Fix #65 by generating card numbers using the Numerify method

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -23,7 +23,7 @@ func (p Payment) CreditCardType() string {
 
 // CreditCardNumber returns a fake credit card number for Payment
 func (p Payment) CreditCardNumber() string {
-	return strconv.Itoa(p.Faker.IntBetween(1000000000000000, 9999999999999999))
+	return p.Faker.Numerify("################")
 }
 
 // CreditCardExpirationDateString returns a fake credit card expiration date in string format for Payment


### PR DESCRIPTION
**Description**

Make use of `faker.Numerify` method instead of rely on Int numbers, to avoid build errors in 32 bits machines.

**Are you trying to fix an existing issue?**

Fixing #65 

**Go Version**

```
$ go version
go version go1.14.5 darwin/amd64
```

**Go Tests**

```
$ go test
PASS
ok  	github.com/jaswdr/faker	1.592s
```
