### PR TITLE
Fix binarysearch tests to be proper incase in case of failure.

### DIFF
--- a/binarystring.go
+++ b/binarystring.go
@@ -1,6 +1,6 @@
 package faker
 
-//BinaryString is the faker struct for BinaryStrict
+//BinaryString is the faker struct for BinaryString
 type BinaryString struct {
 	faker *Faker
 }

--- a/binarystring_test.go
+++ b/binarystring_test.go
@@ -10,7 +10,7 @@ func TestBinaryString(t *testing.T) {
 	inputLength := 11
 	str := f.BinaryString(inputLength)
 
-	Expect(t, len(str), inputLength)
+	Expect(t, inputLength, len(str))
 
 	isStringValid := true
 	for i := 0; i < len(str); i++ {
@@ -19,5 +19,5 @@ func TestBinaryString(t *testing.T) {
 			break
 		}
 	}
-	Expect(t, isStringValid, true)
+	Expect(t, true, isStringValid)
 }


### PR DESCRIPTION
**Description**

In testing, "Expect()" takes "expected" first then "obtained value" to compare. TestBinaryString() had used Expect() with opposite values. Its a small typo which may matter when this tests are expanded. Fixed a comment typo also.

**Are you trying to fix an existing issue?**

No

**Go Version**

```
$ go version
go version go1.17.1 windows/amd64
```

**Go Tests**
PASS
ok      github.com/jaswdr/faker 9.982s
```
$ go test

```
