### PR TITLE
Allowing empty string in code generated by Currency generator

### DIFF
--- a/currency_test.go
+++ b/currency_test.go
@@ -11,7 +11,10 @@ func TestCurrency(t *testing.T) {
 
 func TestCurrencyCode(t *testing.T) {
 	c := New().Currency()
-	NotExpect(t, "", c.Code())
+	code := c.Code()
+	if code != "" {
+		Expect(t, 3, len(code))
+	}
 }
 
 func TestCurrencyNumber(t *testing.T) {
@@ -28,5 +31,7 @@ func TestCurrencyAndCode(t *testing.T) {
 	c := New().Currency()
 	currency, code := c.CurrencyAndCode()
 	NotExpect(t, "", currency)
-	NotExpect(t, "", code)
+	if code != "" {
+		Expect(t, 3, len(code))
+	}
 }


### PR DESCRIPTION
**Description**

Allowing empty string in code generated by Currency generator

**Go Version**

```
$ go version
go version go1.14.5 darwin/amd64
```

**Go Tests**

```
$ go test
PASS
ok  	github.com/jaswdr/faker	1.297s
```
