### PR TITLE
feat: added RandomStringWithLength

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -169,6 +169,14 @@ func (f Faker) RandomLetter() string {
 	return fmt.Sprintf("%c", f.IntBetween(97, 122))
 }
 
+func (f Faker) RandomStringWithLength(l int) string {
+	r := []string{}
+	for i := 0; i < l; i++ {
+		r = append(r, f.RandomLetter())
+	}
+	return strings.Join(r, "")
+}
+
 // RandomStringElement returns a fake random string element from a given list of strings for Faker
 func (f Faker) RandomStringElement(s []string) string {
 	i := f.IntBetween(0, len(s)-1)

--- a/faker_test.go
+++ b/faker_test.go
@@ -154,6 +154,14 @@ func TestRandomLetter(t *testing.T) {
 	Expect(t, 1, len(value))
 }
 
+func TestRandomStringWithLength(t *testing.T){
+	f := New()
+	length := f.IntBetween(97, 1000)
+	value := f.RandomStringWithLength(length)
+	Expect(t, fmt.Sprintf("%T", value), "string")
+	Expect(t, length, len(value))
+}
+
 func TestRandomIntElement(t *testing.T) {
 	f := New()
 	elements := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}


### PR DESCRIPTION
**Description**

I added a calling function to generate a random string of a certain length.

**Are you trying to fix an existing issue?**

#81

**Go Version**

```
abc@c63bccef3747:~/workspace/oss/faker$ go version
go version go1.17.3 linux/amd64
```

**Go Tests**

```
abc@c63bccef3747:~/workspace/oss/faker$ go test
2022/01/24 00:14:32 Transport: unhandled response frame type *http.http2UnknownFrame
PASS
ok      github.com/jaswdr/faker 53.795s
```

(The warning should be from another test that is unrelated to this added functionality)