### PR TITLE
Fixing #83 by handling invalid e-mail names

### DIFF
--- a/faker_test.go
+++ b/faker_test.go
@@ -154,7 +154,7 @@ func TestRandomLetter(t *testing.T) {
 	Expect(t, 1, len(value))
 }
 
-func TestRandomStringWithLength(t *testing.T){
+func TestRandomStringWithLength(t *testing.T) {
 	f := New()
 	length := f.IntBetween(97, 1000)
 	value := f.RandomStringWithLength(length)

--- a/internet.go
+++ b/internet.go
@@ -2,6 +2,7 @@ package faker
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,13 @@ type Internet struct {
 	Faker *Faker
 }
 
+func (i Internet) transformIntoValidEmailName(name string) string {
+	name = strings.ToLower(name)
+	onlyValidCharacters := regexp.MustCompile(`[^a-z0-9._%+\-]+`)
+	name = onlyValidCharacters.ReplaceAllString(name, "_")
+	return name
+}
+
 // User returns a fake user for Internet
 func (i Internet) User() string {
 	user := i.Faker.RandomStringElement(userFormats)
@@ -47,12 +55,12 @@ func (i Internet) User() string {
 
 	// {{firstName}}
 	if strings.Contains(user, "{{firstName}}") {
-		user = strings.Replace(user, "{{firstName}}", strings.ToLower(p.FirstName()), 1)
+		user = strings.Replace(user, "{{firstName}}", i.transformIntoValidEmailName(p.FirstName()), 1)
 	}
 
 	// {{lastName}}
 	if strings.Contains(user, "{{lastName}}") {
-		user = strings.Replace(user, "{{lastName}}", strings.ToLower(p.LastName()), 1)
+		user = strings.Replace(user, "{{lastName}}", i.transformIntoValidEmailName(p.LastName()), 1)
 	}
 
 	return user
@@ -86,7 +94,7 @@ func (i Internet) Email() string {
 
 	// {{user}}
 	if strings.Contains(email, "{{user}}") {
-		email = strings.Replace(email, "{{user}}", i.User(), 1)
+		email = strings.Replace(email, "{{user}}", i.transformIntoValidEmailName(i.User()), 1)
 	}
 
 	// {{domain}}
@@ -106,25 +114,23 @@ func (i Internet) Email() string {
 func (i Internet) FreeEmail() string {
 	domain := i.Faker.RandomStringElement(freeEmailDomain)
 
-	return strings.Join([]string{i.User(), domain}, "@")
+	return strings.Join([]string{i.transformIntoValidEmailName(i.User()), domain}, "@")
 }
 
 // SafeEmail returns a fake safe email address for Internet
 func (i Internet) SafeEmail() string {
-	return strings.Join([]string{i.User(), i.SafeEmailDomain()}, "@")
+	return strings.Join([]string{i.transformIntoValidEmailName(i.User()), i.SafeEmailDomain()}, "@")
 }
 
 // CompanyEmail returns a fake company email address for Internet
 func (i Internet) CompanyEmail() string {
 	c := i.Faker.Company()
 
-	companyName := c.Name()
-	companyName = strings.ToLower(companyName)
-	companyName = strings.Replace(companyName, " ", ".", -1)
+	companyName := i.transformIntoValidEmailName(c.Name())
 
 	domain := strings.Join([]string{companyName, i.Domain()}, ".")
 
-	return strings.Join([]string{i.User(), domain}, "@")
+	return strings.Join([]string{i.transformIntoValidEmailName(i.User()), domain}, "@")
 }
 
 // TLD returns a fake tld for Internet

--- a/internet_test.go
+++ b/internet_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"net/mail"
 	"strings"
 	"testing"
 )
@@ -11,6 +12,11 @@ func TestUser(t *testing.T) {
 	user := i.User()
 	Expect(t, true, len(user) > 0)
 	Expect(t, false, strings.Contains(user, " "))
+}
+
+func isValidEmail(email string) bool {
+	_, err := mail.ParseAddress(email)
+	return err == nil
 }
 
 func TestDomain(t *testing.T) {
@@ -32,6 +38,7 @@ func TestEmail(t *testing.T) {
 	split := strings.Split(email, "@")
 
 	Expect(t, 2, len(split))
+	Expect(t, true, isValidEmail(email))
 }
 
 func TestFreeEmail(t *testing.T) {
@@ -41,6 +48,7 @@ func TestFreeEmail(t *testing.T) {
 	split := strings.Split(email, "@")
 
 	Expect(t, 2, len(split))
+	Expect(t, true, isValidEmail(email))
 }
 
 func TestSafeEmail(t *testing.T) {
@@ -50,6 +58,7 @@ func TestSafeEmail(t *testing.T) {
 	split := strings.Split(email, "@")
 
 	Expect(t, 2, len(split))
+	Expect(t, true, isValidEmail(email))
 }
 
 func TestCompanyEmail(t *testing.T) {
@@ -60,6 +69,7 @@ func TestCompanyEmail(t *testing.T) {
 
 	Expect(t, 2, len(split))
 	Expect(t, false, strings.Contains(email, " "))
+	Expect(t, true, isValidEmail(email))
 }
 
 func TestPassword(t *testing.T) {


### PR DESCRIPTION
**Description**

As reported in #83 some emails names were invalid due to the fact that some first names have `"`, like `O"Connol`. This change fixes that by only allowing valid characters and improve the detection by validating the email address in tests.

**Are you trying to fix an existing issue?**

Fixing #83

**Go Version**

```
$ go version
go version go1.17.3 linux/amd64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker 0.779s
```
