### PR TITLE
Handling edge case in IntBetween when using MaxInt

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -9,6 +9,13 @@ import (
 	"time"
 )
 
+const (
+	maxUint = ^uint(0)
+	minUint = 0
+	maxInt  = int(maxUint >> 1)
+	minInt  = -maxInt - 1
+)
+
 // Faker is the Generator struct for Faker
 type Faker struct {
 	Generator *rand.Rand
@@ -59,28 +66,28 @@ func (f Faker) RandomNumber(size int) int {
 // RandomFloat returns a fake random float number for Faker
 func (f Faker) RandomFloat(maxDecimals, min, max int) float64 {
 	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 10)
+	value, _ := strconv.ParseFloat(s, 32)
 	return value
 }
 
 // Float returns a fake random float number for Faker
 func (f Faker) Float(maxDecimals, min, max int) float64 {
 	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 10)
+	value, _ := strconv.ParseFloat(s, 32)
 	return value
 }
 
 // Float32 returns a fake random float64 number for Faker
 func (f Faker) Float32(maxDecimals, min, max int) float32 {
 	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 10)
+	value, _ := strconv.ParseFloat(s, 32)
 	return float32(value)
 }
 
 // Float64 returns a fake random float64 number for Faker
 func (f Faker) Float64(maxDecimals, min, max int) float64 {
 	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 10)
+	value, _ := strconv.ParseFloat(s, 32)
 	return float64(value)
 }
 
@@ -142,8 +149,16 @@ func (f Faker) UInt64() uint64 {
 func (f Faker) IntBetween(min, max int) int {
 	diff := max - min
 
+	if diff < 0 {
+		diff = 0
+	}
+
 	if diff == 0 {
 		return min
+	}
+
+	if diff == maxInt {
+		return f.Generator.Intn(diff)
 	}
 
 	return f.Generator.Intn(diff+1) + min

--- a/faker_test.go
+++ b/faker_test.go
@@ -108,6 +108,30 @@ func TestIntBetween(t *testing.T) {
 	Expect(t, true, value <= 100)
 }
 
+func TestIntBetweenNegativeValues(t *testing.T) {
+	f := New()
+	value := f.IntBetween(-100, -50)
+	Expect(t, fmt.Sprintf("%T", value), "int")
+	Expect(t, true, value >= -100)
+	Expect(t, true, value <= -50)
+}
+
+func TestIntBetweenWithMaxValues(t *testing.T) {
+	f := New()
+	value := f.IntBetween(minInt, maxInt)
+	Expect(t, fmt.Sprintf("%T", value), "int")
+	Expect(t, true, value >= minInt)
+	Expect(t, true, value <= maxInt)
+}
+
+func TestIntBetweenWithInvalidInterval(t *testing.T) {
+	f := New()
+	value := f.IntBetween(100, 50)
+	Expect(t, fmt.Sprintf("%T", value), "int")
+	Expect(t, true, value >= 50)
+	Expect(t, true, value <= 100)
+}
+
 func TestIntBetweenCanGenerateFirstElementInFirst100GeneratedValues(t *testing.T) {
 	f := New()
 	foundZero := false
@@ -130,6 +154,36 @@ func TestIntBetweenCanGenerateLastElementInFirst100GeneratedValues(t *testing.T)
 		}
 	}
 	Expect(t, true, foundOne)
+}
+
+func TestUint(t *testing.T) {
+	f := New()
+	value := f.UInt()
+	Expect(t, fmt.Sprintf("%T", value), "uint")
+}
+
+func TestUint8(t *testing.T) {
+	f := New()
+	value := f.UInt8()
+	Expect(t, fmt.Sprintf("%T", value), "uint8")
+}
+
+func TestUint16(t *testing.T) {
+	f := New()
+	value := f.UInt16()
+	Expect(t, fmt.Sprintf("%T", value), "uint16")
+}
+
+func TestUint32(t *testing.T) {
+	f := New()
+	value := f.UInt32()
+	Expect(t, fmt.Sprintf("%T", value), "uint32")
+}
+
+func TestUint64(t *testing.T) {
+	f := New()
+	value := f.UInt64()
+	Expect(t, fmt.Sprintf("%T", value), "uint64")
 }
 
 func TestRandomFloat(t *testing.T) {


### PR DESCRIPTION
**Description**

Fixing **IntBetween** by handling edge case where math.MaxInt is used as maximum value.

**Are you trying to fix an existing issue?**

#85 and #87 seems to be related.

**Go Version**

```
$ go version
go version go1.17.6 linux/amd64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker 0.937s
```
