### PR TITLE
Fixing Currency test and add ExpectInInt and ExpectInString test helpers

### DIFF
--- a/currency_test.go
+++ b/currency_test.go
@@ -6,32 +6,35 @@ import (
 
 func TestCurrency(t *testing.T) {
 	c := New().Currency()
-	NotExpect(t, "", c.Currency())
+	currency := c.Currency()
+	NotExpect(t, "", currency)
+	ExpectInString(t, currency, currencies)
 }
 
 func TestCurrencyCode(t *testing.T) {
 	c := New().Currency()
 	code := c.Code()
-	if code != "" {
-		Expect(t, 3, len(code))
-	}
+	NotExpect(t, "", code)
+	ExpectInString(t, code, currenciesCodes)
 }
 
 func TestCurrencyNumber(t *testing.T) {
 	c := New().Currency()
-	NotExpect(t, 0, c.Number())
+	ExpectInInt(t, c.Number(), currenciesNumbers)
 }
 
 func TestCurrencyCountry(t *testing.T) {
 	c := New().Currency()
-	NotExpect(t, "", c.Country())
+	country := c.Country() 
+	NotExpect(t, "", country)
+	ExpectInString(t, country, currenciesCountries)
 }
 
 func TestCurrencyAndCode(t *testing.T) {
 	c := New().Currency()
 	currency, code := c.CurrencyAndCode()
 	NotExpect(t, "", currency)
-	if code != "" {
-		Expect(t, 3, len(code))
-	}
+	NotExpect(t, "", code)
+	ExpectInString(t, currency, currencies)
+	ExpectInString(t, code, currenciesCodes)
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -36,6 +36,36 @@ func NotExpect(t *testing.T, notExpected, got interface{}, values ...interface{}
 	}
 }
 
+func ExpectInInt(t *testing.T, expected int, in []int) {
+	t.Helper()
+	isIn := false
+	for _, v := range in {
+		if expected == v {
+			isIn = true
+			break
+		}
+	}
+
+	if !isIn {
+		t.FailNow()
+	}
+}
+
+func ExpectInString(t *testing.T, expected string, in []string) {
+	t.Helper()
+	isIn := false
+	for _, v := range in {
+		if expected == v {
+			isIn = true
+			break
+		}
+	}
+
+	if !isIn {
+		t.FailNow()
+	}
+}
+
 func F(t *testing.T) Faker {
 	return NewWithSeed(rand.NewSource(0))
 }


### PR DESCRIPTION
**Description**

Fixing `currency.go` tests.

**Are you trying to fix an existing issue?**

No.

**Go Version**

```
$ go version
go version go1.18.2 linux/amd64
```

**Go Tests**

```
$ go test
ok      github.com/jaswdr/faker 1.194s
```
