### PR TITLE
Improve performance using a string builder instead of a string

### DIFF
--- a/binarystring.go
+++ b/binarystring.go
@@ -1,15 +1,17 @@
 package faker
 
-//BinaryString is the faker struct for BinaryString
+import "strings"
+
+// BinaryString is the faker struct for BinaryString
 type BinaryString struct {
 	faker *Faker
 }
 
 // BinaryString returns a random binarystring of given input length
 func (bn BinaryString) BinaryString(length int) string {
-	var bs string
+	var bs strings.Builder
 	for i := 0; i < length; i++ {
-		bs += bn.faker.RandomStringElement([]string{"0", "1"})
+		bs.WriteString(bn.faker.RandomStringElement([]string{"0", "1"}))
 	}
-	return bs
+	return bs.String()
 }

--- a/binarystring_test.go
+++ b/binarystring_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-//tests BinaryString()
+// tests BinaryString()
 func TestBinaryString(t *testing.T) {
 	f := New().BinaryString()
 	inputLength := 11
@@ -20,4 +20,12 @@ func TestBinaryString(t *testing.T) {
 		}
 	}
 	Expect(t, true, isStringValid)
+}
+
+func BenchmarkBinaryString(b *testing.B) {
+	f := New().BinaryString()
+	inputLength := 100
+	for i := 0; i < b.N; i++ {
+		_ = f.BinaryString(inputLength)
+	}
 }

--- a/company.go
+++ b/company.go
@@ -74,27 +74,29 @@ type Company struct {
 }
 
 // CatchPhrase returns a fake catch phrase for Company
-func (c Company) CatchPhrase() (phrase string) {
+func (c Company) CatchPhrase() string {
+	var phrase strings.Builder
 	for i, words := range catchPhraseWords {
 		if i > 0 {
-			phrase += " "
+			phrase.WriteString(" ")
 		}
-		phrase += c.Faker.RandomStringElement(words)
+		phrase.WriteString(c.Faker.RandomStringElement(words))
 	}
 
-	return
+	return phrase.String()
 }
 
 // BS returns a fake bs words for Company
-func (c Company) BS() (bs string) {
+func (c Company) BS() string {
+	var bs strings.Builder
 	for i, words := range bsWords {
 		if i > 0 {
-			bs += " "
+			bs.WriteString(" ")
 		}
-		bs += c.Faker.RandomStringElement(words)
+		bs.WriteString(c.Faker.RandomStringElement(words))
 	}
 
-	return
+	return bs.String()
 }
 
 // Suffix returns a fake suffix for Company

--- a/company_test.go
+++ b/company_test.go
@@ -12,11 +12,25 @@ func TestCompanyCatchPhrase(t *testing.T) {
 	Expect(t, 2, strings.Count(phrase, " ")) // 3 words
 }
 
+func BenchmarkCompanyCatchPhrase(b *testing.B) {
+	f := New().Company()
+	for i := 0; i < b.N; i++ {
+		_ = f.CatchPhrase()
+	}
+}
+
 func TestCompanyBS(t *testing.T) {
 	f := New().Company()
 	bs := f.BS()
 	Expect(t, true, len(bs) > 0)
 	Expect(t, 2, strings.Count(bs, " ")) // 3 words
+}
+
+func BenchmarkCompanyBS(b *testing.B) {
+	f := New().Company()
+	for i := 0; i < b.N; i++ {
+		_ = f.BS()
+	}
 }
 
 func TestCompanySuffix(t *testing.T) {


### PR DESCRIPTION
**Description**

Use string builders instead of a string in functions that uses for loops to concatenate data. Here is the comparison between the main branch and this one. Data generated by benchstat.

```
name                  old time/op  new time/op  delta
BinaryString-8        7.78µs ± 0%  3.61µs ± 0%   ~     (p=1.000 n=1+1)
CompanyCatchPhrase-8   311ns ± 0%   226ns ± 0%   ~     (p=1.000 n=1+1)
CompanyBS-8            315ns ± 0%   231ns ± 0%   ~     (p=1.000 n=1+1)
```

**Are you trying to fix an existing issue?**

Yes #101 

**Go Version**

```
$ go version
go version go1.11 darwin/amd64
```

**Go Tests**

```
$ go test
ok  	faker	6.307s
```
