### PR TITLE
Add Go 1.19.x to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
**Description**

Adding Go version 1.19.x to test matrix, to validate that the library is compatible.

**Are you trying to fix an existing issue?**

N/A

**Go Version**

```
$ go version
# relying on Github Actions
```

**Go Tests**

```
$ go test
# relying on Github Actions
```
