### PR TITLE
Added fake Directories and Absolute File Paths 

### DIFF
--- a/directory.go
+++ b/directory.go
@@ -1,0 +1,40 @@
+package faker
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Directory is a faker struct for Directory
+type Directory struct {
+	Faker *Faker
+}
+
+// Directory returns a fake directory path (the directory path style is dependent OS dependent)
+func (d Directory) Directory(levels int) string {
+	prefix := "/"
+
+	// This will only be true on Windows, coverage may be impacted depending
+	// on host OS
+	if runtime.GOOS == "windows" {
+		prefix = d.DriveLetter()
+	}
+
+	return prefix + filepath.Join(d.Faker.Lorem().Words(levels)...)
+}
+
+// UnixDirectory returns a fake Unix directory path, regardless of the host OS
+func (d Directory) UnixDirectory(levels int) string {
+	return "/" + strings.Join(d.Faker.Lorem().Words(levels), "/")
+}
+
+// WindowsDirectory returns a fake Windows directory path, regardless of the host OS
+func (d Directory) WindowsDirectory(levels int) string {
+	return d.DriveLetter() + strings.Join(d.Faker.Lorem().Words(levels), "\\")
+}
+
+// DriveLetter returns a fake Win32 drive letter
+func (d Directory) DriveLetter() string {
+	return d.Faker.RandomLetter() + ":\\"
+}

--- a/directory.go
+++ b/directory.go
@@ -1,27 +1,23 @@
 package faker
 
 import (
-	"path/filepath"
-	"runtime"
 	"strings"
 )
 
 // Directory is a faker struct for Directory
 type Directory struct {
-	Faker *Faker
+	Faker      *Faker
+	OSResolver OSResolver
 }
 
 // Directory returns a fake directory path (the directory path style is dependent OS dependent)
 func (d Directory) Directory(levels int) string {
-	prefix := "/"
-
-	// This will only be true on Windows, coverage may be impacted depending
-	// on host OS
-	if runtime.GOOS == "windows" {
-		prefix = d.DriveLetter()
+	switch d.OSResolver.OS() {
+	case "windows":
+		return d.WindowsDirectory(levels)
+	default:
+		return d.UnixDirectory(levels)
 	}
-
-	return prefix + filepath.Join(d.Faker.Lorem().Words(levels)...)
 }
 
 // UnixDirectory returns a fake Unix directory path, regardless of the host OS

--- a/directory_test.go
+++ b/directory_test.go
@@ -1,25 +1,26 @@
 package faker
 
 import (
-	"os"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 )
 
+func isUnixPath(path string) bool {
+	return path[0] == '/'
+}
+
+func isWindowsPath(path string) bool {
+	return regexp.MustCompile(`^[a-zA-Z]:\\`).MatchString(path[:3])
+}
+
 func TestDirectory(t *testing.T) {
 	p := New().Directory()
-
 	dir := p.Directory(2)
-	parts := strings.Split(dir, string(os.PathSeparator))
+	Expect(t, true, isUnixPath(dir) || isWindowsPath(dir))
 
-	Expect(t, true, len(parts) == 3)
-	if runtime.GOOS == "windows" {
-		Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
-	} else {
-		Expect(t, true, dir[0] == '/')
-	}
+	p.OSResolver = WindowsOSResolver{}
+	Expect(t, true, isWindowsPath(p.Directory(2)))
 }
 
 func TestUnixDirectory(t *testing.T) {
@@ -29,7 +30,7 @@ func TestUnixDirectory(t *testing.T) {
 	parts := strings.Split(dir, "/")
 
 	Expect(t, true, len(parts) == 3)
-	Expect(t, true, parts[0] == "")
+	Expect(t, true, isUnixPath(dir))
 }
 
 func TestWindowsDirectory(t *testing.T) {
@@ -39,11 +40,10 @@ func TestWindowsDirectory(t *testing.T) {
 	parts := strings.Split(dir, "\\")
 
 	Expect(t, true, len(parts) == 3)
-	Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
+	Expect(t, true, isWindowsPath(dir))
 }
 
 func TestDriveLetter(t *testing.T) {
 	p := New().Directory()
-	reg := regexp.MustCompile(`^[a-zA-Z]:\\`)
-	Expect(t, true, reg.MatchString(p.DriveLetter()))
+	Expect(t, true, isWindowsPath(p.DriveLetter()))
 }

--- a/directory_test.go
+++ b/directory_test.go
@@ -1,0 +1,49 @@
+package faker
+
+import (
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDirectory(t *testing.T) {
+	p := New().Directory()
+
+	dir := p.Directory(2)
+	parts := strings.Split(dir, string(os.PathSeparator))
+
+	Expect(t, true, len(parts) == 3)
+	if runtime.GOOS == "windows" {
+		Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
+	} else {
+		Expect(t, true, dir[0] == '/')
+	}
+}
+
+func TestUnixDirectory(t *testing.T) {
+	p := New().Directory()
+
+	dir := p.UnixDirectory(2)
+	parts := strings.Split(dir, "/")
+
+	Expect(t, true, len(parts) == 3)
+	Expect(t, true, parts[0] == "")
+}
+
+func TestWindowsDirectory(t *testing.T) {
+	p := New().Directory()
+
+	dir := p.WindowsDirectory(2)
+	parts := strings.Split(dir, "\\")
+
+	Expect(t, true, len(parts) == 3)
+	Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
+}
+
+func TestDriveLetter(t *testing.T) {
+	p := New().Directory()
+	reg := regexp.MustCompile(`^[a-zA-Z]:\\`)
+	Expect(t, true, reg.MatchString(p.DriveLetter()))
+}

--- a/faker.go
+++ b/faker.go
@@ -433,12 +433,12 @@ func (f Faker) Image() Image {
 
 // File returns a fake File instance for Faker
 func (f Faker) File() File {
-	return File{&f}
+	return File{&f, OSResolverImpl{}}
 }
 
 // Directory returns a fake Directory instance for Faker
 func (f Faker) Directory() Directory {
-	return Directory{&f}
+	return Directory{&f, OSResolverImpl{}}
 }
 
 // YouTube returns a fake YouTube instance for Faker

--- a/faker.go
+++ b/faker.go
@@ -436,6 +436,11 @@ func (f Faker) File() File {
 	return File{&f}
 }
 
+// Directory returns a fake Directory instance for Faker
+func (f Faker) Directory() Directory {
+	return Directory{&f}
+}
+
 // YouTube returns a fake YouTube instance for Faker
 func (f Faker) YouTube() YouTube {
 	return YouTube{&f}

--- a/file.go
+++ b/file.go
@@ -2,7 +2,6 @@ package faker
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -12,7 +11,8 @@ var (
 
 // File is a faker struct for File
 type File struct {
-	Faker *Faker
+	Faker      *Faker
+	OSResolver OSResolver
 }
 
 // Extension returns a fake Extension file
@@ -30,12 +30,12 @@ func (f File) FilenameWithExtension() string {
 
 // AbsoluteFilePath returns a fake absolute path to a fake file (style is dependent on OS)
 func (f File) AbsoluteFilePath(levels int) string {
-	path := []string{
-		f.Faker.Directory().Directory(levels),
-		f.FilenameWithExtension(),
+	switch f.OSResolver.OS() {
+	case "windows":
+		return f.AbsoluteFilePathForWindows(levels)
+	default:
+		return f.AbsoluteFilePathForUnix(levels)
 	}
-
-	return strings.Join(path, string(os.PathSeparator))
 }
 
 // AbsoluteFilePathForUnix returns a fake absolute unix-style path to a fake file

--- a/file.go
+++ b/file.go
@@ -38,13 +38,13 @@ func (f File) AbsoluteWin32Path(nbLen int) string {
 	return filepath.Join(f.DriveLetter(), f.Directory(nbLen), f.FilenameWithExtension())
 }
 
-// Directory returns a fake directory (the directory path style OS dependent)
+// Directory returns a fake directory (the directory path style is OS dependent)
 func (f File) Directory(nbLen int) string {
 	if runtime.GOOS == "windows" {
 		return f.DriveLetter() + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
-	} else {
-		return "/" + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
 	}
+
+	return "/" + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
 }
 
 // DriveLetter returns a fake Win32 drive letter

--- a/file.go
+++ b/file.go
@@ -2,8 +2,8 @@ package faker
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
+	"os"
+	"strings"
 )
 
 var (
@@ -28,26 +28,32 @@ func (f File) FilenameWithExtension() string {
 	return fmt.Sprintf("%s.%s", text, extension)
 }
 
-// AbsoluteUnixPath returns a fake absolute unix path to a file
-func (f File) AbsoluteUnixPath(nbLen int) string {
-	return filepath.Join(f.Directory(nbLen), f.FilenameWithExtension())
-}
-
-// AbsoluteWin32Path returns a fake absolute win32 path to a file
-func (f File) AbsoluteWin32Path(nbLen int) string {
-	return filepath.Join(f.DriveLetter(), f.Directory(nbLen), f.FilenameWithExtension())
-}
-
-// Directory returns a fake directory (the directory path style is OS dependent)
-func (f File) Directory(nbLen int) string {
-	if runtime.GOOS == "windows" {
-		return f.DriveLetter() + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
+// AbsoluteFilePath returns a fake absolute path to a fake file (style is dependent on OS)
+func (f File) AbsoluteFilePath(levels int) string {
+	path := []string{
+		f.Faker.Directory().Directory(levels),
+		f.FilenameWithExtension(),
 	}
 
-	return "/" + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
+	return strings.Join(path, string(os.PathSeparator))
 }
 
-// DriveLetter returns a fake Win32 drive letter
-func (f File) DriveLetter() string {
-	return f.Faker.RandomLetter() + ":\\"
+// AbsoluteFilePathForUnix returns a fake absolute unix-style path to a fake file
+func (f File) AbsoluteFilePathForUnix(levels int) string {
+	path := []string{
+		f.Faker.Directory().UnixDirectory(levels),
+		f.FilenameWithExtension(),
+	}
+
+	return strings.Join(path, "/")
+}
+
+// AbsoluteFilePathForWindows returns a fake absolute win32-style path to a fake file
+func (f File) AbsoluteFilePathForWindows(levels int) string {
+	path := []string{
+		f.Faker.Directory().WindowsDirectory(levels),
+		f.FilenameWithExtension(),
+	}
+
+	return strings.Join(path, "\\")
 }

--- a/file.go
+++ b/file.go
@@ -1,6 +1,10 @@
 package faker
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
 
 var (
 	extensions = []string{"ods", "xls", "xlsx", "csv", "ics", "vcf", "3dm", "3ds", "max", "bmp", "dds", "gif", "jpg", "jpeg", "png", "psd", "xcf", "tga", "thm", "tif", "tiff", "yuv", "ai", "eps", "ps", "svg", "dwg", "dxf", "gpx", "kml", "kmz", "webp", "3g2", "3gp", "aaf", "asf", "avchd", "avi", "drc", "flv", "m2v", "m4p", "m4v", "mkv", "mng", "mov", "mp2", "mp4", "mpe", "mpeg", "mpg", "mpv", "mxf", "nsv", "ogg", "ogv", "ogm", "qt", "rm", "rmvb", "roq", "srt", "svi", "vob", "webm", "wmv", "yuv", "aac", "aiff", "ape", "au", "flac", "gsm", "it", "m3u", "m4a", "mid", "mod", "mp3", "mpa", "pls", "ra", "s3m", "sid", "wav", "wma", "xm", "7z", "a", "apk", "ar", "bz2", "cab", "cpio", "deb", "dmg", "egg", "gz", "iso", "jar", "lha", "mar", "pea", "rar", "rpm", "s7z", "shar", "tar", "tbz2", "tgz", "tlz", "war", "whl", "xpi", "zip", "zipx", "xz", "pak", "exe", "msi", "bin", "command", "sh", "bat", "crx", "c", "cc", "class", "clj", "cpp", "cs", "cxx", "el", "go", "h", "java", "lua", "m", "m4", "php", "pl", "po", "py", "rb", "rs", "sh", "swift", "vb", "vcxproj", "xcodeproj", "xml", "diff", "patch", "html", "js", "html", "htm", "css", "js", "jsx", "less", "scss", "wasm", "php", "eot", "otf", "ttf", "woff", "woff2", "ppt", "odp", "doc", "docx", "ebook", "log", "md", "msg", "odt", "org", "pages", "pdf", "rtf", "rst", "tex", "txt", "wpd", "wps", "mobi", "epub", "azw1", "azw3", "azw4", "azw6", "azw", "cbr", "cbz"}
@@ -22,4 +26,28 @@ func (f File) FilenameWithExtension() string {
 	text := f.Faker.Lorem().Word()
 
 	return fmt.Sprintf("%s.%s", text, extension)
+}
+
+// AbsoluteUnixPath returns a fake absolute unix path to a file
+func (f File) AbsoluteUnixPath(nbLen int) string {
+	return filepath.Join(f.Directory(nbLen), f.FilenameWithExtension())
+}
+
+// AbsoluteWin32Path returns a fake absolute win32 path to a file
+func (f File) AbsoluteWin32Path(nbLen int) string {
+	return filepath.Join(f.DriveLetter(), f.Directory(nbLen), f.FilenameWithExtension())
+}
+
+// Directory returns a fake directory (the directory path style OS dependent)
+func (f File) Directory(nbLen int) string {
+	if runtime.GOOS == "windows" {
+		return f.DriveLetter() + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
+	} else {
+		return "/" + filepath.Join(f.Faker.Lorem().Words(nbLen)...)
+	}
+}
+
+// DriveLetter returns a fake Win32 drive letter
+func (f File) DriveLetter() string {
+	return f.Faker.RandomLetter() + ":\\"
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,9 +1,7 @@
 package faker
 
 import (
-	"path/filepath"
-	"regexp"
-	"runtime"
+	"os"
 	"strings"
 	"testing"
 )
@@ -22,11 +20,16 @@ func TestAbsolutePath(t *testing.T) {
 	p := New().File()
 
 	path := p.AbsoluteFilePath(2)
-	Expect(t, true, filepath.IsAbs(path))
+	parts := strings.Split(path, string(os.PathSeparator))
+	Expect(t, true, isUnixPath(path) || isWindowsPath(path))
+	Expect(t, true, len(parts) == 4)
+	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
 
-	if runtime.GOOS == "windows" {
-		Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(path[:2]))
-	}
+	p.OSResolver = WindowsOSResolver{}
+	path = p.AbsoluteFilePath(2)
+	Expect(t, true, isWindowsPath(p.AbsoluteFilePath(2)))
+	Expect(t, true, len(parts) == 4)
+	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
 }
 
 func TestAbsoluteFilePathForUnix(t *testing.T) {
@@ -35,7 +38,7 @@ func TestAbsoluteFilePathForUnix(t *testing.T) {
 	path := p.AbsoluteFilePathForUnix(2)
 	parts := strings.Split(path, "/")
 
-	Expect(t, true, path[0] == '/')
+	Expect(t, true, isUnixPath(path))
 	Expect(t, true, len(parts) == 4)
 	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
 }
@@ -46,7 +49,7 @@ func TestAbsoluteFilePathForWindows(t *testing.T) {
 	path := p.AbsoluteFilePathForWindows(2)
 	parts := strings.Split(path, "\\")
 
-	Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
+	Expect(t, true, isWindowsPath(path))
 	Expect(t, true, len(parts) == 4)
 	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
 }

--- a/file_test.go
+++ b/file_test.go
@@ -27,6 +27,7 @@ func TestAbsolutePath(t *testing.T) {
 
 	p.OSResolver = WindowsOSResolver{}
 	path = p.AbsoluteFilePath(2)
+	parts = strings.Split(path, "\\")
 	Expect(t, true, isWindowsPath(p.AbsoluteFilePath(2)))
 	Expect(t, true, len(parts) == 4)
 	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)

--- a/file_test.go
+++ b/file_test.go
@@ -1,6 +1,9 @@
 package faker
 
 import (
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -13,4 +16,24 @@ func TestExtension(t *testing.T) {
 func TestFileWithExtension(t *testing.T) {
 	p := New().File()
 	Expect(t, true, len(strings.Split(p.FilenameWithExtension(), ".")) == 2)
+}
+
+func TestDirectory(t *testing.T) {
+	p := New().File()
+	Expect(t, true, len(strings.Split(p.Directory(2), string(filepath.Separator))) == 3)
+}
+
+func TestDriveLetter(t *testing.T) {
+	p := New().File()
+	reg := regexp.MustCompile(`^[a-zA-Z]:\\`)
+	Expect(t, true, reg.MatchString(p.DriveLetter()))
+}
+
+func TestAbsolutePath(t *testing.T) {
+	p := New().File()
+	if runtime.GOOS == "windows" {
+		Expect(t, true, filepath.IsAbs(p.AbsoluteWin32Path(3)))
+	} else {
+		Expect(t, true, filepath.IsAbs(p.AbsoluteUnixPath(3)))
+	}
 }

--- a/file_test.go
+++ b/file_test.go
@@ -18,22 +18,35 @@ func TestFileWithExtension(t *testing.T) {
 	Expect(t, true, len(strings.Split(p.FilenameWithExtension(), ".")) == 2)
 }
 
-func TestDirectory(t *testing.T) {
-	p := New().File()
-	Expect(t, true, len(strings.Split(p.Directory(2), string(filepath.Separator))) == 3)
-}
-
-func TestDriveLetter(t *testing.T) {
-	p := New().File()
-	reg := regexp.MustCompile(`^[a-zA-Z]:\\`)
-	Expect(t, true, reg.MatchString(p.DriveLetter()))
-}
-
 func TestAbsolutePath(t *testing.T) {
 	p := New().File()
+
+	path := p.AbsoluteFilePath(2)
+	Expect(t, true, filepath.IsAbs(path))
+
 	if runtime.GOOS == "windows" {
-		Expect(t, true, filepath.IsAbs(p.AbsoluteWin32Path(3)))
-	} else {
-		Expect(t, true, filepath.IsAbs(p.AbsoluteUnixPath(3)))
+		Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(path[:2]))
 	}
+}
+
+func TestAbsoluteFilePathForUnix(t *testing.T) {
+	p := New().File()
+
+	path := p.AbsoluteFilePathForUnix(2)
+	parts := strings.Split(path, "/")
+
+	Expect(t, true, path[0] == '/')
+	Expect(t, true, len(parts) == 4)
+	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
+}
+
+func TestAbsoluteFilePathForWindows(t *testing.T) {
+	p := New().File()
+
+	path := p.AbsoluteFilePathForWindows(2)
+	parts := strings.Split(path, "\\")
+
+	Expect(t, true, regexp.MustCompile(`^[a-zA-Z]:`).MatchString(parts[0]))
+	Expect(t, true, len(parts) == 4)
+	Expect(t, true, len(strings.Split(parts[len(parts)-1], ".")) == 2)
 }

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 )
 
 const (
@@ -41,4 +42,17 @@ type TempFileCreatorImpl struct{}
 // TempFile creates a temporary file
 func (TempFileCreatorImpl) TempFile(prefix string) (f *os.File, err error) {
 	return ioutil.TempFile(os.TempDir(), prefix)
+}
+
+// OSResolver returns the GOOS value for operating an operating system
+type OSResolver interface {
+	OS() string
+}
+
+// OSResolverImpl is the default implementation of OSResolver
+type OSResolverImpl struct{}
+
+// OS returns the runtime.GOOS value for the host operating system
+func (OSResolverImpl) OS() string {
+	return runtime.GOOS
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package faker
 import (
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -42,4 +43,15 @@ func TestTempFileCreatorImplCanCreateTempFiles(t *testing.T) {
 	Expect(t, err, nil)
 	Expect(t, true, strings.Contains(f.Name(), "prefix"))
 	Expect(t, f.Close(), nil)
+}
+
+type WindowsOSResolver struct{}
+
+func (WindowsOSResolver) OS() string {
+	return "windows"
+}
+
+func TestOSResolverImplReturnsGOOS(t *testing.T) {
+	resolver := OSResolverImpl{}
+	Expect(t, runtime.GOOS, resolver.OS())
 }


### PR DESCRIPTION
**Description**

This PR adds fake directories to file.go, including tests. 

**Are you trying to fix an existing issue?**

No

**Go Version**

```
$ go version
# replace this line with the output
```

**Go Tests**

```
➜  faker git:(file_directories) ✗ go test -v -run "TestDriveLetter|TestAbsolutePath|TestDirectory"
=== RUN   TestDirectory
--- PASS: TestDirectory (0.00s)
=== RUN   TestDriveLetter
--- PASS: TestDriveLetter (0.00s)
=== RUN   TestAbsolutePath
--- PASS: TestAbsolutePath (0.00s)
PASS
ok      github.com/jaswdr/faker 0.004s


➜  faker git:(file_directories) ✗ GOOS=windows go test -v -run "TestDriveLetter|TestAbsolutePath|TestDirectory"
=== RUN   TestDirectory
--- PASS: TestDirectory (0.00s)
=== RUN   TestDriveLetter
--- PASS: TestDriveLetter (0.00s)
=== RUN   TestAbsolutePath
--- PASS: TestAbsolutePath (0.00s)
PASS
ok      github.com/jaswdr/faker 0.166s

```
