### PR TITLE
Fix signature of UintBetween generator functions

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -199,23 +199,23 @@ func (f Faker) UIntBetween(min, max uint) uint {
 }
 
 // UInt8Between returns a fake UInt8 between a given minimum and maximum values for Faker
-func (f Faker) UInt8Between(min, max int8) uint8 {
-	return uint8(f.IntBetween(int(min), int(max)))
+func (f Faker) UInt8Between(min, max uint8) uint8 {
+	return uint8(f.UIntBetween(uint(min), uint(max)))
 }
 
 // UInt16Between returns a fake UInt16 between a given minimum and maximum values for Faker
-func (f Faker) UInt16Between(min, max int16) uint16 {
-	return uint16(f.IntBetween(int(min), int(max)))
+func (f Faker) UInt16Between(min, max uint16) uint16 {
+	return uint16(f.UIntBetween(uint(min), uint(max)))
 }
 
 // UInt32Between returns a fake UInt32 between a given minimum and maximum values for Faker
 func (f Faker) UInt32Between(min, max uint32) uint32 {
-	return uint32(f.IntBetween(int(min), int(max)))
+	return uint32(f.UIntBetween(uint(min), uint(max)))
 }
 
 // UInt64Between returns a fake UInt64 between a given minimum and maximum values for Faker
 func (f Faker) UInt64Between(min, max uint64) uint64 {
-	return uint64(f.IntBetween(int(min), int(max)))
+	return uint64(f.UIntBetween(uint(min), uint(max)))
 }
 
 // Letter returns a fake single letter for Faker


### PR DESCRIPTION
Signature of function Uint(8/16/32/64)Between is replaced from int params to uint params. 
Also for more idiomatic way that methods now calling to base UIntBetween instead of IntBetween.

**Go Version**

```
$ go version
go version go1.19.5 darwin/arm64
```

**Go Tests**

```
$ go test
2023/02/27 21:59:56 Error while requesting https://loremflickr.com/300/200 : request failed
2023/02/27 21:59:57 Error while creating a temp file: temp file creation failed
2023/02/27 21:59:58 Error while requesting https://thispersondoesnotexist.com/image : request failed
2023/02/27 21:59:58 Error while creating a temp file: temp file creation failed
PASS
ok      github.com/jaswdr/faker 5.998s
```
