### PR TITLE
Update the Variant bits in method V4() of uuid.go

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -16,6 +16,6 @@ func (UUID) V4() (uuid string) {
 	var uiq [16]byte
 	io.ReadFull(rand.Reader, uiq[:])
 	uiq[6] = (uiq[6] & 0x0f) | 0x40           // Version 4
-	uiq[8] = (uiq[8]&(0xff>>2) | (0x02 << 6)) // Variant RFC4122
+	uiq[8] = (uiq[8] & 0x3f) | 0x80           // Variant RFC4122
 	return fmt.Sprintf("%x-%x-%x-%x-%x", uiq[0:4], uiq[4:6], uiq[6:8], uiq[8:10], uiq[10:])
 }


### PR DESCRIPTION
**Description**

I changed the way the Variant bits were set in method V4() of uuid.go

**Are you trying to fix an existing issue?**

I'm trying to fix issue #134

The variant bits are set to RFC4122 by AND-ing the original bits with 0x3f and OR-ing them with 0x80.
Now, each time you run the code, it should generate a random UUID version 4

**Go Version**

```
$ go version
go version go1.19.5 windows/amd64   
```

**Go Tests**

```
$ go test

=== RUN   TestUUIDv4
--- PASS: TestUUIDv4 (0.00s)
PASS
ok      github.com/jaswdr/faker 0.034s

=== RUN   TestUUIDV4UniqueInSequence
--- PASS: TestUUIDV4UniqueInSequence (0.00s)
PASS
ok      github.com/jaswdr/faker 0.025s

```
