### PR TITLE
New feature for get realistic words according a context

### DIFF
--- a/realistic_word.go
+++ b/realistic_word.go
@@ -1,0 +1,66 @@
+package faker
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type WordInfo struct {
+	Word  string   `json:"word"`
+	Score int      `json:"score"`
+	Tags  []string `json:"tags"`
+}
+
+const apiEndpoint = "https://api.datamuse.com/words?ml=%s&max=%d"
+
+var consultService = func(context string, max int, w *[]WordInfo) {
+	replaceContext := strings.Replace(context, " ", "+", -1)
+	apiURL := fmt.Sprintf(apiEndpoint, replaceContext, max)
+
+	resData, err := http.Get(apiURL)
+	if err != nil {
+		fmt.Println("Error in HTTP request:", err)
+		return
+	}
+	defer resData.Body.Close()
+
+	bodyRes, err := ioutil.ReadAll(resData.Body)
+	if err != nil {
+		fmt.Println("Error reading response data:", err)
+		return
+	}
+
+	err = json.Unmarshal([]byte(bodyRes), &w)
+	if err != nil {
+		fmt.Println("Error deserializing JSON:", err)
+		return
+	}
+}
+
+func getWords(context string) []string {
+	var words []WordInfo
+	consultService(context, 20, &words)
+
+	result := []string{}
+	for _, word := range words {
+		result = append(result, word.Word)
+	}
+	return result
+}
+
+func getRandomIndex(max int) int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Intn(max + 1)
+}
+
+func getWord(context string) string {
+	var words []WordInfo
+	consultService(context, 10, &words)
+	randIndex := getRandomIndex(len(words) - 1)
+	return words[randIndex].Word
+}

--- a/realistic_word_test.go
+++ b/realistic_word_test.go
@@ -9,7 +9,6 @@ func TestGetWord(t *testing.T) {
 		context     string
 		mockFunc    func()
 		expectWords []string
-		expectWord  string
 	}{
 		{
 			context: "test",
@@ -23,7 +22,6 @@ func TestGetWord(t *testing.T) {
 				}
 			},
 			expectWords: []string{"test1", "test2", "test3"},
-			expectWord:  "test1",
 		},
 	}
 
@@ -35,8 +33,15 @@ func TestGetWord(t *testing.T) {
 			t.Errorf("getWords(%s) was incorrect, got: %d, want: %d.", table.context, len(resultWords), len(table.expectWords))
 		}
 		resultWord := getWord(table.context)
-		if resultWord != table.expectWord {
-			t.Errorf("getWord(%s) was incorrect, got: %s, want: %s.", table.context, resultWord, table.expectWord)
+		valid := false
+		for _, w := range table.expectWords {
+			if w == resultWord {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			t.Errorf("getWord(%s) was incorrect, got: %s.", table.context, resultWord)
 		}
 		consultService = originalResponse
 	}

--- a/realistic_word_test.go
+++ b/realistic_word_test.go
@@ -1,0 +1,43 @@
+package faker
+
+import (
+	"testing"
+)
+
+func TestGetWord(t *testing.T) {
+	tables := []struct {
+		context     string
+		mockFunc    func()
+		expectWords []string
+		expectWord  string
+	}{
+		{
+			context: "test",
+			mockFunc: func() {
+				consultService = func(context string, max int, w *[]WordInfo) {
+					*w = []WordInfo{
+						{Word: "test1", Score: 1, Tags: []string{"tag1"}},
+						{Word: "test2", Score: 2, Tags: []string{"tag2"}},
+						{Word: "test3", Score: 3, Tags: []string{"tag3"}},
+					}
+				}
+			},
+			expectWords: []string{"test1", "test2", "test3"},
+			expectWord:  "test1",
+		},
+	}
+
+	originalResponse := consultService
+	for _, table := range tables {
+		table.mockFunc()
+		resultWords := getWords(table.context)
+		if len(resultWords) != len(table.expectWords) {
+			t.Errorf("getWords(%s) was incorrect, got: %d, want: %d.", table.context, len(resultWords), len(table.expectWords))
+		}
+		resultWord := getWord(table.context)
+		if resultWord != table.expectWord {
+			t.Errorf("getWord(%s) was incorrect, got: %s, want: %s.", table.context, resultWord, table.expectWord)
+		}
+		consultService = originalResponse
+	}
+}


### PR DESCRIPTION
**Description**
My solution consists in consuming an API that allows to query a list of words related to a context, for example, for the context of a pastry shop, we can receive the following result: 
List: pastry, pastrycook, patissier,: bakeshop, confectionary, cakery, pastry chef, pastrymaker, pasteler, bakery, pastrymaking, boulangerie, croissanterie, bakehouse, cake shop, pieshop, doughnutery, baker's, paste
Or if you prefer, a single random word from this list: pastrymaker

**Are you trying to fix an existing issue?**

#143 

**Go Version**

```
$ go version
go version go1.21.3 linux/amd64
```

**Go Tests**

```
$ go test
2023/10/30 11:27:12 Error while requesting https://loremflickr.com/300/200 : request failed
2023/10/30 11:27:13 Error while creating a temp file: temp file creation failed
2023/10/30 11:27:13 Error while requesting https://randomuser.me : request failed
2023/10/30 11:27:13 Error while creating a temp file: temp file creation failed
PASS
ok      github.com/jaswdr/faker 5.128s
```
