### PR TITLE
Fix Int* and UInt* return only 0s

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -103,53 +103,75 @@ func (f Faker) Int() int {
 
 // Int8 returns a fake Int8 number for Faker
 func (f Faker) Int8() int8 {
-	return int8(f.Int())
+	return int8(f.IntBetween(0, math.MaxInt8))
 }
 
 // Int16 returns a fake Int16 number for Faker
 func (f Faker) Int16() int16 {
-	return int16(f.Int())
+	return int16(f.IntBetween(0, math.MaxInt16))
 }
 
 // Int32 returns a fake Int32 number for Faker
 func (f Faker) Int32() int32 {
-	return int32(f.Int())
+	return int32(f.IntBetween(0, math.MaxInt32))
 }
 
 // Int64 returns a fake Int64 number for Faker
 func (f Faker) Int64() int64 {
-	return int64(f.Int())
+	return int64(f.IntBetween(0, math.MaxInt64))
 }
 
 // UInt returns a fake UInt number for Faker
 func (f Faker) UInt() uint {
-	max := math.MaxInt
-	return uint(f.IntBetween(0, max))
+	return uint(f.IntBetween(0, math.MaxInt))
 }
 
 // UInt8 returns a fake UInt8 number for Faker
 func (f Faker) UInt8() uint8 {
-	return uint8(f.Int())
+	return uint8(f.IntBetween(0, math.MaxUint8))
 }
 
 // UInt16 returns a fake UInt16 number for Faker
 func (f Faker) UInt16() uint16 {
-	return uint16(f.Int())
+	return uint16(f.IntBetween(0, math.MaxUint16))
 }
 
 // UInt32 returns a fake UInt32 number for Faker
 func (f Faker) UInt32() uint32 {
-	return uint32(f.Int())
+	return uint32(f.IntBetween(0, math.MaxUint32))
 }
 
 // UInt64 returns a fake UInt64 number for Faker
 func (f Faker) UInt64() uint64 {
-	return uint64(f.Int())
+	// Using MaxUint32 to avoid overflow
+	return uint64(f.IntBetween(0, math.MaxUint32))
 }
 
 // IntBetween returns a fake Int between a given minimum and maximum values for Faker
 func (f Faker) IntBetween(min, max int) int {
-	diff := max - min
+	if min > max {
+		// Swap values
+		return f.IntBetween(max, min)
+	}
+
+	diff := 0
+	// Edge case when min and max are actual min and max integers,
+	// since we cannot store 2 * math.MaxInt, we instead split the range in:
+	// - 50% chance to return a negative number
+	// - 50% chance to return a positive number
+	if min == math.MinInt64 && max == math.MaxInt64 {
+		if f.Bool() {
+			// negatives
+			max = 0
+			diff = math.MaxInt
+		} else {
+			// positives
+			min = 0
+			diff = math.MaxInt
+		}
+	} else {
+		diff = max - min
+	}
 
 	var value int
 	if diff == 0 {

--- a/faker_test.go
+++ b/faker_test.go
@@ -125,10 +125,38 @@ func TestInt8(t *testing.T) {
 	Expect(t, fmt.Sprintf("%T", value), "int8")
 }
 
+func TestInt8ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.Int8()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
+}
+
 func TestInt16(t *testing.T) {
 	f := New()
 	value := f.Int16()
 	Expect(t, fmt.Sprintf("%T", value), "int16")
+}
+
+func TestInt16ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.Int16()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
 }
 
 func TestInt32(t *testing.T) {
@@ -137,10 +165,38 @@ func TestInt32(t *testing.T) {
 	Expect(t, fmt.Sprintf("%T", value), "int32")
 }
 
+func TestInt32ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.Int32()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
+}
+
 func TestInt64(t *testing.T) {
 	f := New()
 	value := f.Int64()
 	Expect(t, fmt.Sprintf("%T", value), "int64")
+}
+
+func TestInt64ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.Int64()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
 }
 
 func TestIntBetween(t *testing.T) {
@@ -151,6 +207,13 @@ func TestIntBetween(t *testing.T) {
 	Expect(t, true, value <= 100)
 }
 
+func TestIntBetweenWithSameValues(t *testing.T) {
+	f := New()
+	value := f.IntBetween(1, 1)
+	Expect(t, fmt.Sprintf("%T", value), "int")
+	Expect(t, 1, value)
+}
+
 func TestIntBetweenNegativeValues(t *testing.T) {
 	f := New()
 	value := f.IntBetween(-100, -50)
@@ -159,12 +222,53 @@ func TestIntBetweenNegativeValues(t *testing.T) {
 	Expect(t, true, value <= -50)
 }
 
-func TestIntBetweenWithMaxValues(t *testing.T) {
+func TestIntBetweenWithNegativeMinGeneratesNegativeValues(t *testing.T) {
 	f := New()
-	value := f.IntBetween(math.MinInt, math.MaxInt)
-	Expect(t, fmt.Sprintf("%T", value), "int")
-	Expect(t, true, value >= math.MinInt)
-	Expect(t, true, value <= math.MaxInt)
+	foundNegative := false
+	for i := 0; i < 100; i++ {
+		value := f.IntBetween(-100, 100)
+		if value < 0 {
+			foundNegative = true
+			break
+		}
+	}
+
+	Expect(t, true, foundNegative)
+}
+
+func TestIntBetweenWithMinMaxIntReturnDifferentValues(t *testing.T) {
+	f := New()
+	value1 := f.IntBetween(math.MinInt, math.MaxInt)
+	value2 := f.IntBetween(math.MinInt, math.MaxInt)
+	Expect(t, value1 != value2, true, value1, value2)
+}
+
+func TestIntBetweenWithMinMaxInt8ReturnDifferentValues(t *testing.T) {
+	f := New()
+	value1 := f.IntBetween(math.MinInt8, math.MaxInt8)
+	value2 := f.IntBetween(math.MinInt8, math.MaxInt8)
+	Expect(t, value1 != value2, true, value1, value2)
+}
+
+func TestIntBetweenWithMinMaxInt16ReturnDifferentValues(t *testing.T) {
+	f := New()
+	value1 := f.IntBetween(math.MinInt16, math.MaxInt16)
+	value2 := f.IntBetween(math.MinInt16, math.MaxInt16)
+	Expect(t, value1 != value2, true, value1, value2)
+}
+
+func TestIntBetweenWithMinMaxInt32ReturnDifferentValues(t *testing.T) {
+	f := New()
+	value1 := f.IntBetween(math.MinInt32, math.MaxInt32)
+	value2 := f.IntBetween(math.MinInt32, math.MaxInt32)
+	Expect(t, value1 != value2, true, value1, value2)
+}
+
+func TestIntBetweenWithMinMaxInt64ReturnDifferentValues(t *testing.T) {
+	f := New()
+	value1 := f.IntBetween(math.MinInt64, math.MaxInt64)
+	value2 := f.IntBetween(math.MinInt64, math.MaxInt64)
+	Expect(t, value1 != value2, true, value1, value2)
 }
 
 func TestIntBetweenWithInvalidInterval(t *testing.T) {
@@ -205,10 +309,38 @@ func TestUint(t *testing.T) {
 	Expect(t, fmt.Sprintf("%T", value), "uint")
 }
 
+func TestUIntReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.UInt()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
+}
+
 func TestUint8(t *testing.T) {
 	f := New()
 	value := f.UInt8()
 	Expect(t, fmt.Sprintf("%T", value), "uint8")
+}
+
+func TestUInt8ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.UInt8()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
 }
 
 func TestUint16(t *testing.T) {
@@ -217,16 +349,58 @@ func TestUint16(t *testing.T) {
 	Expect(t, fmt.Sprintf("%T", value), "uint16")
 }
 
+func TestUInt16ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.UInt16()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
+}
+
 func TestUint32(t *testing.T) {
 	f := New()
 	value := f.UInt32()
 	Expect(t, fmt.Sprintf("%T", value), "uint32")
 }
 
+func TestUInt32ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.UInt32()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
+}
+
 func TestUint64(t *testing.T) {
 	f := New()
 	value := f.UInt64()
 	Expect(t, fmt.Sprintf("%T", value), "uint64")
+}
+
+func TestUInt64ReturnsNonZeroValues(t *testing.T) {
+	f := New()
+	nonZero := false
+	for i := 0; i < 100; i++ {
+		value := f.UInt64()
+		if value > 0 {
+			nonZero = true
+			break
+		}
+	}
+
+	Expect(t, nonZero, true)
 }
 
 func TestUIntBetween(t *testing.T) {


### PR DESCRIPTION
**Description**

Change the way Int* and UInt* are generated to avoid returning only 0s.

**Are you trying to fix an existing issue?**

fixes #164

**Go Version**

```
$ go version
go version go1.21.6 linux/amd64
```

**Go Tests**

```
$  go test ./...
ok      github.com/jaswdr/faker/v2
```
