### PR TITLE
add: random element and weighted random element.

### DIFF
--- a/faker_test.go
+++ b/faker_test.go
@@ -556,6 +556,13 @@ func TestMap(t *testing.T) {
 	Expect(t, true, len(mp) > 0)
 }
 
+func TestRandomStringElement(t *testing.T) {
+	f := New()
+	m := []string{"str1", "str2"}
+	randomStr := f.RandomStringElement(m)
+	Expect(t, true, randomStr == "str1" || randomStr == "str2")
+}
+
 func TestRandomStringMapKey(t *testing.T) {
 	f := New()
 	m := map[string]string{"k0": "v0", "k1": "v1"}

--- a/random_element.go
+++ b/random_element.go
@@ -1,0 +1,26 @@
+package faker
+
+// RandomElement returns a fake random element from a given list of elements
+func RandomElement[T any](f Faker, elements ...T) T {
+	i := f.IntBetween(0, len(elements)-1)
+	return elements[i]
+}
+
+// RandomElementWeighted takes faker instance and a list of elements in the form of map[weight]element,
+// it then selects one of the elements randomly and returns it,
+//
+// Elements with higher weight have more chance to be returned.
+func RandomElementWeighted[T any](f Faker, elements map[int]T) T {
+	arrayOfElements := make([]T, 0)
+
+	for weight, value := range elements {
+		// TODO: there is an accepted proposal for generic slices.Repeat function in Go 1.23
+		for i := 0; i < weight; i++ {
+			arrayOfElements = append(arrayOfElements, value)
+		}
+	}
+
+	i := f.IntBetween(0, len(arrayOfElements)-1)
+
+	return arrayOfElements[i]
+}

--- a/random_element_test.go
+++ b/random_element_test.go
@@ -1,0 +1,25 @@
+package faker
+
+import "testing"
+
+func TestRandomElement(t *testing.T) {
+	f := New()
+	m := []string{"str1", "str2"}
+	randomStr := RandomElement(f, m...)
+	Expect(t, true, randomStr == "str1" || randomStr == "str2")
+}
+
+func TestRandomElementWeighted(t *testing.T) {
+	f := New()
+	m := map[int]string{
+		0: "zeroChance",
+		1: "someChance",
+		5: "moreChance",
+	}
+
+	for i := 0; i < 5; i++ {
+		got := RandomElementWeighted(f, m)
+		Expect(t, true, got == "someChance" || got == "moreChance")
+		Expect(t, true, got != "zeroChance")
+	}
+}

--- a/time.go
+++ b/time.go
@@ -33,7 +33,7 @@ func (t Time) TimeBetween(min, max time.Time) time.Time {
 // ISO8601 returns a fake time in ISO8601 format for Time
 func (t Time) ISO8601(max time.Time) string {
 	t1 := t.Time(max)
-	return t1.Format("2006-02-01T15:04:05+000")
+	return t1.Format("2006-01-02T15:04:05+000")
 }
 
 // ANSIC returns a fake time in ANSIC format for Time


### PR DESCRIPTION
**Description**

Currently, there are `RandomStringElement` and `RandomIntElement` methods in the package, but what happens if e.g. we want to select one of the users that are of type `type User struct{...}`, we may need a generic random select function and that's the reason I implemented RandomElement function.

Also, what happens if we want to give more chances to some elements? I added RandomElementWeighted for that purpose.

+ Added required test cases for previous functions and a test for `RandomStringElement`

Unfortunately, due to golang lack of support for typed parameters, these new two functions couldn't be methods and are implemented as functions taking Faker as argument (not receiver).

-----
There was also a small change in `time.ISO8601` function for how we format the time, as mentioned in [this pkg](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/timeformat)

**Are you trying to fix an existing issue?**
No

**Go Version**

```
$ go version
go version go1.22.2 darwin/arm64
```

**Go Tests**
[Runned on pipeline](https://github.com/arshamalh/faker/actions/runs/8740205986)
```
$ go test
ok  	github.com/jaswdr/faker/v2	2.833s
```
