### PR TITLE
Fix credit card expiration date

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -2,6 +2,7 @@ package faker
 
 import (
 	"fmt"
+	"time"
 )
 
 var cardVendors = []string{
@@ -25,9 +26,11 @@ func (p Payment) CreditCardNumber() string {
 	return p.Faker.Numerify("################")
 }
 
-// CreditCardExpirationDateString returns a fake credit card expiration date in string format for Payment
+// CreditCardExpirationDateString returns a fake credit card expiration date in string format (i.e. mm/yy) for Payment
 func (p Payment) CreditCardExpirationDateString() string {
-	day := p.Faker.IntBetween(0, 30)
-	month := p.Faker.IntBetween(12, 30)
-	return fmt.Sprintf("%02d/%02d", day, month)
+	month := p.Faker.IntBetween(1, 12)
+	currentYear := time.Now().Year()
+	year := p.Faker.IntBetween(currentYear, currentYear+3)
+
+	return fmt.Sprintf("%02d/%02d", month, year%100)
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -1,7 +1,7 @@
 package faker
 
 import (
-	"strings"
+	"regexp"
 	"testing"
 )
 
@@ -19,6 +19,6 @@ func TestCreditCardExpirationDateString(t *testing.T) {
 	p := New().Payment()
 
 	date := p.CreditCardExpirationDateString()
-	Expect(t, 5, len(date))
-	Expect(t, true, strings.Contains(date, "/"))
+	re := regexp.MustCompile(`^(0[1-9]|1[0-2])/\d{2}$`)
+	Expect(t, true, re.MatchString(date))
 }


### PR DESCRIPTION
**Description**

Fix credit card expiration date.

The generated expiration dates were in date/month format when they should be in month/year format.
Also, the month generated was between 12 and 30 when it should have been between 1 and 12.

**Are you trying to fix an existing issue?**

This issue is not reported in github.

**Go Version**

```
$ go version
go version go1.22.2 darwin/amd64
```

**Go Tests**

```
$ go test
2024/04/24 17:23:36 Error while requesting https://loremflickr.com/300/200 : request failed
2024/04/24 17:23:36 Error while creating a temp file: temp file creation failed
2024/04/24 17:23:36 Error while requesting https://randomuser.me : request failed
2024/04/24 17:23:36 Error while creating a temp file: temp file creation failed
PASS
ok  	github.com/jaswdr/faker/v2	1.668s
```
