### PR TITLE
Removing tests run for Go 1.20.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
**Description**

As stated in README, only the last 2 versions of Go are supported

**Are you trying to fix an existing issue?**

N/A

**Go Version**

N/A

**Go Tests**

N/A