### PR TITLE
fix: Float functions should return the proper number of decimals

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -68,30 +68,54 @@ func (f Faker) RandomNumber(size int) int {
 
 // RandomFloat returns a fake random float number for Faker
 func (f Faker) RandomFloat(maxDecimals, min, max int) float64 {
-	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 32)
-	return value
+	value := float64(f.IntBetween(min, max-1))
+	if maxDecimals < 1 {
+		return value
+	}
+
+	p := int(math.Pow10(maxDecimals))
+	decimals := float64(f.IntBetween(0, p)) / float64(p)
+
+	return value + decimals
 }
 
 // Float returns a fake random float number for Faker
 func (f Faker) Float(maxDecimals, min, max int) float64 {
-	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 32)
-	return value
+	value := float64(f.IntBetween(min, max-1))
+	if maxDecimals < 1 {
+		return value
+	}
+
+	p := int(math.Pow10(maxDecimals))
+	decimals := float64(f.IntBetween(0, p)) / float64(p)
+
+	return value + decimals
 }
 
-// Float32 returns a fake random float64 number for Faker
+// Float32 returns a fake random float32 number for Faker
 func (f Faker) Float32(maxDecimals, min, max int) float32 {
-	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 32)
-	return float32(value)
+	value := float32(f.IntBetween(min, max-1))
+	if maxDecimals < 1 {
+		return value
+	}
+
+	p := int(math.Pow10(maxDecimals))
+	decimals := float32(f.IntBetween(0, p)) / float32(p)
+
+	return value + decimals
 }
 
 // Float64 returns a fake random float64 number for Faker
 func (f Faker) Float64(maxDecimals, min, max int) float64 {
-	s := fmt.Sprintf("%d.%d", f.IntBetween(min, max-1), f.IntBetween(1, maxDecimals))
-	value, _ := strconv.ParseFloat(s, 32)
-	return float64(value)
+	value := float64(f.IntBetween(min, max-1))
+	if maxDecimals < 1 {
+		return value
+	}
+
+	p := int(math.Pow10(maxDecimals))
+	decimals := float64(f.IntBetween(0, p)) / float64(p)
+
+	return value + decimals
 }
 
 // Int returns a fake Int number for Faker

--- a/faker_test.go
+++ b/faker_test.go
@@ -445,10 +445,39 @@ func TestUInt64Between(t *testing.T) {
 
 func TestRandomFloat(t *testing.T) {
 	f := New()
-	value := f.RandomFloat(1, 1, 100)
+	value := f.RandomFloat(2, 1, 100)
 	Expect(t, fmt.Sprintf("%T", value), "float64")
 	Expect(t, true, value >= 1)
 	Expect(t, true, value <= 100)
+	Expect(t, math.Round(value*100)/100, value)
+}
+
+func TestFloat(t *testing.T) {
+	f := New()
+	value := f.Float(2, 1, 100)
+	Expect(t, fmt.Sprintf("%T", value), "float64")
+	Expect(t, true, value >= 1)
+	Expect(t, true, value <= 100)
+	Expect(t, math.Round(value*100)/100, value)
+}
+
+func TestFloat32(t *testing.T) {
+	f := New()
+	value := f.Float32(2, 1, 100)
+	Expect(t, fmt.Sprintf("%T", value), "float32")
+	Expect(t, true, value >= 1)
+	Expect(t, true, value <= 100)
+	rounded := float32(math.Round(float64(value*100))/100)
+	Expect(t, rounded, value)
+}
+
+func TestFloat64(t *testing.T) {
+	f := New()
+	value := f.Float64(2, 1, 100)
+	Expect(t, fmt.Sprintf("%T", value), "float64")
+	Expect(t, true, value >= 1)
+	Expect(t, true, value <= 100)
+	Expect(t, math.Round(value*100)/100, value)
 }
 
 func TestLetter(t *testing.T) {


### PR DESCRIPTION
**Description**

Fix the float functions to return the proper number of decimals, based off of the maxDecimals argument. Prior to this fix, a random value was generated between 0 and `maxDecimals` and that was used as the decimal portion. This meant that values generated with maxDecimals=2, the decimal portion of all generated values would be either `.0`, `.1` or `.2`, instead of there being 2 digits in the decimal portion. With the fix, values generated with maxDecimals=2 will have a decimal portion anywhere between `.00` and `.99`, inclusively.

Missing tests were also added for `Float`, `Float32` and `Float64`

**Are you trying to fix an existing issue?**

https://github.com/jaswdr/faker/issues/177

**Go Version**

```
$ go version
go version go1.23.2 darwin/arm64
```

**Go Tests**

```
$ go test
2024/10/08 11:59:21 Error while requesting https://loremflickr.com/300/200 : request failed
2024/10/08 11:59:22 Error while creating a temp file: temp file creation failed
2024/10/08 11:59:22 Error while requesting https://randomuser.me : request failed
2024/10/08 11:59:22 Error while creating a temp file: temp file creation failed
PASS
ok      github.com/jaswdr/faker/v2      2.974s
```
