### PR TITLE
Remove % from address building number

### DIFF
--- a/address.go
+++ b/address.go
@@ -10,7 +10,7 @@ var (
 
 	citySuffix = []string{"town", "ton", "land", "ville", "berg", "burgh", "borough", "bury", "view", "port", "mouth", "stad", "furt", "chester", "mouth", "fort", "haven", "side", "shire"}
 
-	buildingNumber = []string{"%####", "%###", "%##"}
+	buildingNumber = []string{"####", "###", "##"}
 
 	streetSuffix = []string{
 		"Alley", "Avenue",


### PR DESCRIPTION
**Description**

Remove unnecessary `%` character from building number.

**Are you trying to fix an existing issue?**

#180 