### PR TITLE
feat: Add RandomMapKey and RandomMapValue

### DIFF
--- a/random_element.go
+++ b/random_element.go
@@ -24,3 +24,23 @@ func RandomElementWeighted[T any](f Faker, elements map[int]T) T {
 
 	return arrayOfElements[i]
 }
+
+func RandomMapKey[K comparable, V any](f Faker, m map[K]V) K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	i := f.IntBetween(0, len(keys)-1)
+	return keys[i]
+}
+
+func RandomMapValue[K comparable, V any](f Faker, m map[K]V) V {
+	values := make([]V, 0, len(m))
+	for k := range m {
+		values = append(values, m[k])
+	}
+
+	i := f.IntBetween(0, len(values)-1)
+	return values[i]
+}

--- a/random_element_test.go
+++ b/random_element_test.go
@@ -23,3 +23,27 @@ func TestRandomElementWeighted(t *testing.T) {
 		Expect(t, true, got != "zeroChance")
 	}
 }
+
+func TestRandomMapKey(t *testing.T) {
+	f := New()
+	m := map[int]string{
+		1:  "one",
+		5:  "five",
+		42: "forty two",
+	}
+
+	randomInt := RandomMapKey(f, m)
+	Expect(t, true, randomInt == 1 || randomInt == 5 || randomInt == 42)
+}
+
+func TestRandomMapValue(t *testing.T) {
+	f := New()
+	m := map[int]string{
+		1:  "one",
+		5:  "five",
+		42: "forty two",
+	}
+
+	randomStr := RandomMapValue(f, m)
+	Expect(t, true, randomStr == "one" || randomStr == "five" || randomStr == "forty two")
+}


### PR DESCRIPTION
**Description**

Add two generic functions, analog to to RandomStringMapKey and RandomStringMapValue, in the same way RandomElement is to RandomStringElement.

This was something I felt was missing as I was trying to get a random map element from a map than was not a `map[string]string`.

Unlike their String counterpart though, no sorting is performed. Doing a sort would require the generics to be constrained to `cmd.Ordered` which I feel is too restrictive.

**Are you trying to fix an existing issue?**

No

**Go Version**

```
$ go version
go version go1.23.2 darwin/arm64
```

**Go Tests**

```
$ go test
PASS
ok      github.com/jaswdr/faker/v2      7.547s
```
