### PR TITLE
feat: Enhance struct filling with recursive support and depth control

### DIFF
--- a/struct_test.go
+++ b/struct_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+// Test types
 type Basic struct {
 	s string
 	S string
@@ -52,16 +53,22 @@ type NestedArray struct {
 	NA []StructArray `fakesize:"2"`
 }
 
+// Test cases
 func TestStructBasic(t *testing.T) {
 	var basic Basic
 	New().Struct().Fill(&basic)
+
+	// Private field should remain empty
 	Expect(t, "", basic.s)
+	// Public field should be filled
 	NotExpect(t, "", basic.S)
 }
 
 func TestStructNested(t *testing.T) {
 	var nested Nested
 	New().Struct().Fill(&nested)
+
+	// Check nested struct fields
 	NotExpect(t, "", nested.A)
 	NotExpect(t, nil, nested.B)
 	NotExpect(t, "", nested.B.S)
@@ -71,6 +78,8 @@ func TestStructNested(t *testing.T) {
 func TestStructBuiltInTypes(t *testing.T) {
 	var builtIn BuiltIn
 	New().Struct().Fill(&builtIn)
+
+	// Check all built-in types are filled
 	NotExpect(t, nil, builtIn.Uint8)
 	NotExpect(t, nil, builtIn.Uint16)
 	NotExpect(t, nil, builtIn.Uint32)
@@ -88,44 +97,64 @@ func TestStructBuiltInTypes(t *testing.T) {
 func TestStructWithFunction(t *testing.T) {
 	var function Function
 	New().Struct().Fill(&function)
+
+	// Check function tags are respected
 	NotExpect(t, "", function.Number)
 	NotExpect(t, "", function.Name)
-	NotExpect(t, "ABC", function.Const)
+	Expect(t, "ABC", *function.Const)
 }
 
 func TestStructArray(t *testing.T) {
 	var sa StructArray
 	New().Struct().Fill(&sa)
-	NotExpect(t, 0, sa.Bars)
-	NotExpect(t, 0, sa.Builds)
+
+	// Check array fields
+	NotExpect(t, 0, len(sa.Bars))
+	NotExpect(t, 0, len(sa.Builds))
+
+	// Check strings array with fakesize
 	Expect(t, 3, len(sa.Strings))
 	for _, s := range sa.Strings {
 		NotExpect(t, "", s)
 		Expect(t, 4, len(s))
 	}
+
+	// Check fixed length array
 	Expect(t, 5, len(sa.SetLen))
 	for _, s := range sa.SetLen {
 		NotExpect(t, "", s)
 	}
+
+	// Check nested arrays
 	for _, s := range sa.SubStr {
 		for _, ss := range s {
 			NotExpect(t, "", ss)
 		}
 	}
+
+	// Check fixed length nested arrays
 	for _, s := range sa.SubStrLen {
 		Expect(t, 2, len(s))
 		for _, ss := range s {
 			NotExpect(t, "", ss)
 		}
 	}
-	NotExpect(t, "", sa.Empty)
-	NotExpect(t, "", sa.Skips)
+
+	// Check empty array
+	Expect(t, 0, len(sa.Empty))
+
+	// Check skipped array
+	Expect(t, 0, len(sa.Skips))
+
+	// Check array with fakesize
 	Expect(t, 3, len(sa.Multy))
 }
 
 func TestStructNestedArray(t *testing.T) {
 	var na NestedArray
 	New().Struct().Fill(&na)
+
+	// Check nested array with fakesize
 	Expect(t, 2, len(na.NA))
 	for _, elem := range na.NA {
 		NotExpect(t, 0, len(elem.Builds))
@@ -142,6 +171,7 @@ func TestStructToInt(t *testing.T) {
 		IntGenerate int64 `fake:"{number:1,10}"`
 	}
 	New().Struct().Fill(&si)
+
 	NotExpect(t, 0, si.Int)
 	NotExpect(t, 0, si.IntConst)
 	NotExpect(t, 0, si.IntGenerate)
@@ -154,6 +184,7 @@ func TestStructToUint(t *testing.T) {
 		UintGenerate uint64 `fake:"{number:1,10}"`
 	}
 	New().Struct().Fill(&su)
+
 	NotExpect(t, 0, su.Uint)
 	NotExpect(t, 0, su.UintConst)
 	NotExpect(t, 0, su.UintGenerate)
@@ -166,6 +197,7 @@ func TestStructToFloat(t *testing.T) {
 		FloatGenerate float32 `fake:"{latitude}"`
 	}
 	New().Struct().Fill(&sf)
+
 	NotExpect(t, 0, sf.Float)
 	NotExpect(t, 0, sf.FloatConst)
 	NotExpect(t, 0, sf.FloatGenerate)
@@ -178,6 +210,7 @@ func TestStructToBool(t *testing.T) {
 		BoolGenerate bool `fake:"{bool}"`
 	}
 	New().Struct().Fill(&sf)
+
 	NotExpect(t, nil, sf.Bool)
 	NotExpect(t, nil, sf.BoolConst)
 	NotExpect(t, nil, sf.BoolGenerate)
@@ -188,6 +221,7 @@ func TestStructUUID(t *testing.T) {
 		UUID string `fake`
 	}
 	New().Struct().Fill(&st)
+
 	NotExpect(t, "", st.UUID)
 }
 
@@ -197,11 +231,129 @@ func TestStructUUIDInSequence(t *testing.T) {
 	}
 	fake := New()
 	before := ""
+
+	// Test 100 sequential UUIDs
 	for i := 0; i < 100; i++ {
 		fake.Struct().Fill(&st)
 		after := st.UUID
+
+		// UUID should not be empty
 		NotExpect(t, true, after == "")
+		// UUID should be different from previous
 		Expect(t, false, before == after)
 		before = after
 	}
+}
+
+func TestStructWithChildStructures(t *testing.T) {
+	type Child struct {
+		Name   string
+		Age    int
+		Active bool
+	}
+
+	type Parent struct {
+		ID       string `fake`
+		Child    Child
+		Children []Child `fakesize:"3"`
+		Optional *Child
+	}
+
+	var p Parent
+	New().Struct().Fill(&p)
+
+	// Test parent fields
+	NotExpect(t, "", p.ID)
+
+	// Test embedded child struct
+	NotExpect(t, "", p.Child.Name)
+	NotExpect(t, 0, p.Child.Age)
+	NotExpect(t, nil, p.Child.Active)
+
+	// Test slice of child structs
+	Expect(t, 3, len(p.Children))
+	for _, child := range p.Children {
+		NotExpect(t, "", child.Name)
+		NotExpect(t, 0, child.Age)
+		NotExpect(t, nil, child.Active)
+	}
+
+	// Test pointer to child struct
+	NotExpect(t, nil, p.Optional)
+	NotExpect(t, "", p.Optional.Name)
+	NotExpect(t, 0, p.Optional.Age)
+	NotExpect(t, nil, p.Optional.Active)
+}
+
+func TestNestedStructures(t *testing.T) {
+	type Address struct {
+		Street string
+		City   string
+		ZIP    string `fake:"#####"`
+	}
+
+	type Contact struct {
+		Email   string `fake:"????.????@example.com"`
+		Phone   string `fake:"###-###-####"`
+		Address Address
+	}
+
+	type Person struct {
+		ID      uint64
+		Name    string
+		Contact Contact
+	}
+
+	var p Person
+	New().Struct().Fill(&p)
+
+	// Test top level fields
+	NotExpect(t, 0, p.ID)
+	NotExpect(t, "", p.Name)
+
+	// Test nested contact
+	NotExpect(t, "", p.Contact.Email)
+	NotExpect(t, "", p.Contact.Phone)
+
+	// Test deeply nested address
+	NotExpect(t, "", p.Contact.Address.Street)
+	NotExpect(t, "", p.Contact.Address.City)
+	NotExpect(t, "", p.Contact.Address.ZIP)
+}
+
+func TestRecursiveStruct(t *testing.T) {
+	type Node struct {
+		Value    string
+		Parent   *Node
+		Children []*Node `fakesize:"2"`
+	}
+
+	var root Node
+	New().Struct().Fill(&root)
+
+	NotExpect(t, nil, root.Parent)
+	Expect(t, 2, len(root.Children))
+
+	for _, child := range root.Children {
+		NotExpect(t, nil, child.Parent)
+		Expect(t, 2, len(child.Children))
+		for _, grandchild := range child.Children {
+			NotExpect(t, nil, grandchild.Parent)
+			Expect(t, 2, len(grandchild.Children))
+		}
+	}
+}
+
+func TestStructWithDepth(t *testing.T) {
+	type Node struct {
+		Value string
+		Child *Node `fakesize:"2"`
+	}
+
+	var n Node
+	New().Struct().FillWithDepth(&n, 3)
+
+	NotExpect(t, "", n.Value)
+	NotExpect(t, "", n.Child.Value)
+	Expect(t, "", n.Child.Child.Value)
 }


### PR DESCRIPTION
**Description**

- Added FillWithDepth method to allow specifying maximum recursion depth for nested structs.
- Improved fillValue method to handle recursive structures and nested arrays.
- Updated tests to cover new functionality, including child structures and nested arrays with fakesize.
- Enhanced existing tests for clarity and coverage of various struct types.

**Are you trying to fix an existing issue?**

Fix stack overflow when attempting to use recursive structs.

**Go Version**

```
$ go version
go version go1.24.2 linux/amd64
```

**Go Tests**

```
$ go test
ok      github.com/jaswdr/faker/v2      2.448s
```
