### PR TITLE
Fixed RandomDigitNot function

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -96,7 +96,7 @@ func (f Faker) RandomDigitNot(ignore ...int) int {
 
 	for {
 		current := f.RandomDigit()
-		if inSlice(current, ignore) {
+		if !inSlice(current, ignore) {
 			return current
 		}
 	}


### PR DESCRIPTION
**Description**

The logic inside was the exact opposite of the description.

It could only return digits in the ignore list 🤦

**Are you trying to fix an existing issue?**

Replace this line with a link to the issue you are trying to fix

**Go Version**

```
$ go version
go version go1.24.1 darwin/arm64
```

**Go Tests**

```
$ go test
2025/07/19 20:59:40 Error while requesting https://loremflickr.com/300/200 : request failed
2025/07/19 20:59:41 Error while creating a temp file: temp file creation failed
2025/07/19 20:59:41 Error while requesting https://randomuser.me : request failed
2025/07/19 20:59:41 Error while creating a temp file: temp file creation failed
PASS
ok  	github.com/jaswdr/faker/v2	2.462s
```
