### PR TITLE
Fix documentation drift across README, godoc, and tooling config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,7 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_root = "github.com/jaswdr/faker"
+  import_root = "github.com/jaswdr/faker/v2"
 
 [[transformers]]
 name = "gofmt"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your Go file
 import "github.com/jaswdr/faker/v2"
 ```
 
-And run `go get` or `dep ensure` to get the package.
+And run `go get` to fetch the package.
 
 ## Basic Usage
 
@@ -122,7 +122,7 @@ fmt.Println(profileImage.Name())
 // /tmp/profil-picture-img-4022222298.jfif
 ```
 
-See more formatters in [docs](https://pkg.go.dev/github.com/jaswdr/faker?tab=doc)
+See more formatters in [docs](https://pkg.go.dev/github.com/jaswdr/faker/v2?tab=doc)
 
 ## Development
 
@@ -152,4 +152,4 @@ Faker is released under the MIT Licence. See the bundled LICENSE file for detail
 
 ## Maintainer
 
-Created and maitained by Jonathan Schweder ([@jaswdr](https://github.com/jaswdr)) and [many others](https://github.com/jaswdr/faker/graphs/contributors)
+Created and maintained by Jonathan Schweder ([@jaswdr](https://github.com/jaswdr)) and [many others](https://github.com/jaswdr/faker/graphs/contributors)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
 | 1.x.x   | :white_check_mark: |
 | < 0.x.x | :x:                |
 

--- a/faker.go
+++ b/faker.go
@@ -18,13 +18,17 @@
 // Struct Filling (using struct tags):
 //
 //	type User struct {
-//		Name  string `fake:"{{person.first_name}} {{person.last_name}}"`
-//		Email string `fake:"{{internet.email}}"`
-//		Age   int    `fake:"{{number.number_int_between 18 65}}"`
+//		Name  string `fake:"????????"`
+//		Email string `fake:"??????@??????.com"`
+//		Age   int    // filled automatically based on field type
 //	}
 //
 //	var user User
 //	f.Struct().Fill(&user)
+//
+// Pattern characters: # (digit), ? (letter), * (letter or digit).
+// Use fake:"skip" to skip a field, fakesize:"N" for slices/arrays/maps,
+// and RegisterFunction for custom generators via fake:"fn=name".
 //
 // Performance Characteristics:
 //


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects stale and misleading documentation across the project.

## Changes

- **README**: Fix pkg.go.dev link to v2 module path, remove deprecated `dep ensure` reference, fix "maintained" typo
- **faker.go**: Update package godoc struct tag examples to reflect actual `Bothify`/`Numerify` pattern behavior instead of unimplemented `{{provider.method}}` syntax
- **SECURITY.md**: Add v2.x to supported versions table
- **.deepsource.toml**: Fix `import_root` to `github.com/jaswdr/faker/v2`

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

