### PR TITLE
Generate Luhn-valid credit card numbers with brand-specific formats

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -2,6 +2,8 @@ package faker
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -9,6 +11,34 @@ var cardVendors = []string{
 	"Visa", "Visa", "Visa", "Visa", "Visa",
 	"MasterCard", "MasterCard", "MasterCard", "MasterCard", "MasterCard",
 	"American Express", "Discover Card", "Visa Retired",
+}
+
+type cardBrandConfig struct {
+	prefixes []string
+	length   int
+}
+
+var cardBrandConfigs = map[string]cardBrandConfig{
+	"Visa": {
+		prefixes: []string{"4"},
+		length:   16,
+	},
+	"MasterCard": {
+		prefixes: []string{"51", "52", "53", "54", "55"},
+		length:   16,
+	},
+	"American Express": {
+		prefixes: []string{"34", "37"},
+		length:   15,
+	},
+	"Discover Card": {
+		prefixes: []string{"6011", "65"},
+		length:   16,
+	},
+	"Visa Retired": {
+		prefixes: []string{"4"},
+		length:   13,
+	},
 }
 
 // Payment is a faker struct for Payment
@@ -21,9 +51,67 @@ func (p Payment) CreditCardType() string {
 	return p.Faker.RandomStringElement(cardVendors)
 }
 
-// CreditCardNumber returns a fake credit card number for Payment
+// CreditCardNumber returns a Luhn-valid fake credit card number for a random card type.
 func (p Payment) CreditCardNumber() string {
-	return p.Faker.Numerify("################")
+	return p.CreditCardNumberForType(p.CreditCardType())
+}
+
+// CreditCardNumberForType returns a Luhn-valid fake credit card number for the given card type.
+func (p Payment) CreditCardNumberForType(cardType string) string {
+	config, ok := cardBrandConfigs[cardType]
+	if !ok {
+		config = cardBrandConfigs["Visa"]
+	}
+
+	prefix := p.Faker.RandomStringElement(config.prefixes)
+	return generateLuhnNumber(*p.Faker, prefix, config.length)
+}
+
+// generateLuhnNumber builds a Luhn-valid number with the given prefix and total length.
+func generateLuhnNumber(f Faker, prefix string, length int) string {
+	if length <= len(prefix) {
+		return prefix
+	}
+
+	remaining := length - len(prefix) - 1
+	partial := prefix + f.Numerify(strings.Repeat("#", remaining))
+	checkDigit := luhnCheckDigit(partial)
+	return partial + strconv.Itoa(checkDigit)
+}
+
+// luhnCheckDigit computes the Luhn check digit for a partial card number (without check digit).
+func luhnCheckDigit(partial string) int {
+	sum := 0
+	for i := 0; i < len(partial); i++ {
+		d := int(partial[len(partial)-1-i] - '0')
+		if i%2 == 0 {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	return (10 - (sum % 10)) % 10
+}
+
+// IsValidLuhn returns true if the given numeric string passes the Luhn checksum.
+func IsValidLuhn(number string) bool {
+	sum := 0
+	for i := 0; i < len(number); i++ {
+		if number[len(number)-1-i] < '0' || number[len(number)-1-i] > '9' {
+			return false
+		}
+		d := int(number[len(number)-1-i] - '0')
+		if i%2 == 1 {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	return sum%10 == 0
 }
 
 // CreditCardExpirationDateString returns a fake credit card expiration date in string format (i.e. mm/yy) for Payment

--- a/payment_test.go
+++ b/payment_test.go
@@ -12,7 +12,37 @@ func TestCreditCardType(t *testing.T) {
 
 func TestCreditCardNumber(t *testing.T) {
 	p := New().Payment()
-	Expect(t, true, len(p.CreditCardNumber()) > 0)
+	number := p.CreditCardNumber()
+	Expect(t, true, len(number) >= 13)
+	Expect(t, true, IsValidLuhn(number))
+}
+
+func TestCreditCardNumberForType(t *testing.T) {
+	p := New().Payment()
+
+	tests := []struct {
+		cardType string
+		length   int
+		prefix   string
+	}{
+		{"Visa", 16, "4"},
+		{"MasterCard", 16, "5"},
+		{"American Express", 15, "3"},
+		{"Discover Card", 16, "6"},
+		{"Visa Retired", 13, "4"},
+	}
+
+	for _, tt := range tests {
+		number := p.CreditCardNumberForType(tt.cardType)
+		Expect(t, tt.length, len(number))
+		Expect(t, true, IsValidLuhn(number))
+		Expect(t, tt.prefix, string(number[0]))
+	}
+}
+
+func TestIsValidLuhn(t *testing.T) {
+	Expect(t, true, IsValidLuhn("4532015112830366"))
+	Expect(t, false, IsValidLuhn("4532015112830367"))
 }
 
 func TestCreditCardExpirationDateString(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Credit card numbers are now Luhn-valid and use brand-appropriate lengths and prefixes.

## Changes

- Add `luhnCheckDigit` and `IsValidLuhn` helpers
- Add `CreditCardNumberForType(cardType)` with per-brand configuration (Visa 16-digit, Amex 15-digit, etc.)
- `CreditCardNumber()` now generates Luhn-valid numbers for a random card type
- Expanded tests covering checksum validity, lengths, and prefixes per brand

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

