### PR TITLE
Return errors from image providers instead of panicking

### DIFF
--- a/image.go
+++ b/image.go
@@ -29,9 +29,8 @@ type Image struct {
 }
 
 // Image returns a fake image file.
-// Width and height must be positive values. Panics on file creation or encoding errors
-// to maintain backward compatibility with existing API contract.
-func (i Image) Image(width, height int) *os.File {
+// Width and height must be positive values; non-positive values default to 100.
+func (i Image) Image(width, height int) (*os.File, error) {
 	// Input validation - use reasonable defaults instead of nil to avoid breaking changes
 	if width <= 0 {
 		width = 100
@@ -73,13 +72,14 @@ func (i Image) Image(width, height int) *os.File {
 
 	f, err := i.TempFileCreator.TempFile("fake-img-*.png")
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	err = i.PngEncoder.Encode(f, img)
 	if err != nil {
-		panic(err)
+		f.Close()
+		return nil, err
 	}
 
-	return f
+	return f, nil
 }

--- a/image.go
+++ b/image.go
@@ -29,23 +29,31 @@ type Image struct {
 }
 
 // Image returns a fake image file.
-// Width and height must be positive values; non-positive values default to 100.
-func (i Image) Image(width, height int) (*os.File, error) {
-	// Input validation - use reasonable defaults instead of nil to avoid breaking changes
+// Width and height must be positive values. Panics on file creation or encoding errors
+// to maintain backward compatibility with existing API contract.
+func (i Image) Image(width, height int) *os.File {
+	f, err := i.ImageFile(width, height)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// ImageFile returns a fake image file without panicking on errors.
+func (i Image) ImageFile(width, height int) (*os.File, error) {
 	if width <= 0 {
 		width = 100
 	}
 	if height <= 0 {
 		height = 100
 	}
-
-	// Reasonable limits to prevent excessive memory usage
 	if width > 10000 {
 		width = 10000
 	}
 	if height > 10000 {
 		height = 10000
 	}
+
 	upLeft := image.Point{0, 0}
 	lowRight := image.Point{width, height}
 	img := image.NewRGBA(image.Rectangle{upLeft, lowRight})

--- a/image_test.go
+++ b/image_test.go
@@ -18,26 +18,47 @@ func (creator ErrorRaiserPngEncoder) Encode(_ io.Writer, _ image.Image) error {
 
 func TestImage(t *testing.T) {
 	f := New()
-	value, err := f.Image().Image(100, 100)
-	Expect(t, nil, err)
+	value := f.Image().Image(100, 100)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".png"), true, value.Name())
 }
 
-func TestImageErrorIfTempFileCreationFails(t *testing.T) {
+func TestImagePanicIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	img := f.Image()
 	expected := fmt.Errorf("temp file creation failed")
 	img.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	_, err := img.Image(100, 100)
-	Expect(t, expected, err)
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	img.Image(100, 100)
 }
 
-func TestImageErrorIfEncodingFails(t *testing.T) {
+func TestImagePanicIfEncodingFails(t *testing.T) {
 	f := New()
 	img := f.Image()
 	expected := fmt.Errorf("png encoding failed")
 	img.PngEncoder = ErrorRaiserPngEncoder{err: expected}
-	_, err := img.Image(100, 100)
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	img.Image(100, 100)
+}
+
+func TestImageFileErrorIfTempFileCreationFails(t *testing.T) {
+	f := New()
+	img := f.Image()
+	expected := fmt.Errorf("temp file creation failed")
+	img.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
+	_, err := img.ImageFile(100, 100)
+	Expect(t, expected, err)
+}
+
+func TestImageFileErrorIfEncodingFails(t *testing.T) {
+	f := New()
+	img := f.Image()
+	expected := fmt.Errorf("png encoding failed")
+	img.PngEncoder = ErrorRaiserPngEncoder{err: expected}
+	_, err := img.ImageFile(100, 100)
 	Expect(t, expected, err)
 }

--- a/image_test.go
+++ b/image_test.go
@@ -18,29 +18,26 @@ func (creator ErrorRaiserPngEncoder) Encode(_ io.Writer, _ image.Image) error {
 
 func TestImage(t *testing.T) {
 	f := New()
-	value := f.Image().Image(100, 100)
+	value, err := f.Image().Image(100, 100)
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".png"), true, value.Name())
 }
 
-func TestImagePanicIfTempFileCreationFails(t *testing.T) {
+func TestImageErrorIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	img := f.Image()
 	expected := fmt.Errorf("temp file creation failed")
 	img.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	img.Image(100, 100)
+	_, err := img.Image(100, 100)
+	Expect(t, expected, err)
 }
 
-func TestImagePanicIfEncodingFails(t *testing.T) {
+func TestImageErrorIfEncodingFails(t *testing.T) {
 	f := New()
 	img := f.Image()
 	expected := fmt.Errorf("png encoding failed")
 	img.PngEncoder = ErrorRaiserPngEncoder{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	img.Image(100, 100)
+	_, err := img.Image(100, 100)
+	Expect(t, expected, err)
 }

--- a/lorem_flickr.go
+++ b/lorem_flickr.go
@@ -2,6 +2,7 @@ package faker
 
 import (
 	"io"
+	"log"
 	"os"
 	"strconv"
 )
@@ -16,7 +17,17 @@ type LoremFlickr struct {
 }
 
 // Image generates a *os.File with a random image using the loremflickr.com service.
-func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) (*os.File, error) {
+// Panics on failure to maintain backward compatibility.
+func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) *os.File {
+	f, err := lf.ImageFile(width, height, categories, prefix, categoriesStrict)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// ImageFile generates a *os.File with a random image using the loremflickr.com service.
+func (lf LoremFlickr) ImageFile(width, height int, categories []string, prefix string, categoriesStrict bool) (*os.File, error) {
 	url := loremFlickrBaseURL
 
 	switch prefix {
@@ -35,13 +46,10 @@ func (lf LoremFlickr) Image(width, height int, categories []string, prefix strin
 	url += string('/') + strconv.Itoa(width) + string('/') + strconv.Itoa(height)
 
 	if len(categories) > 0 {
-
 		url += string('/')
-
 		for _, category := range categories {
 			url += category + string(',')
 		}
-
 		if categoriesStrict {
 			url += "/all"
 		}
@@ -49,12 +57,14 @@ func (lf LoremFlickr) Image(width, height int, categories []string, prefix strin
 
 	resp, err := lf.HTTPClient.Get(url)
 	if err != nil {
+		log.Println("Error while requesting", url, ":", err)
 		return nil, err
 	}
 
 	defer resp.Body.Close()
 	f, err := lf.TempFileCreator.TempFile("loremflickr-img-*.jpg")
 	if err != nil {
+		log.Println("Error while creating a temp file:", err)
 		return nil, err
 	}
 

--- a/lorem_flickr.go
+++ b/lorem_flickr.go
@@ -2,7 +2,6 @@ package faker
 
 import (
 	"io"
-	"log"
 	"os"
 	"strconv"
 )
@@ -16,8 +15,8 @@ type LoremFlickr struct {
 	TempFileCreator TempFileCreator
 }
 
-// Image generates a *os.File with a random image using the loremflickr.com service
-func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) *os.File {
+// Image generates a *os.File with a random image using the loremflickr.com service.
+func (lf LoremFlickr) Image(width, height int, categories []string, prefix string, categoriesStrict bool) (*os.File, error) {
 	url := loremFlickrBaseURL
 
 	switch prefix {
@@ -50,17 +49,19 @@ func (lf LoremFlickr) Image(width, height int, categories []string, prefix strin
 
 	resp, err := lf.HTTPClient.Get(url)
 	if err != nil {
-		log.Println("Error while requesting", url, ":", err)
-		panic(err)
+		return nil, err
 	}
 
 	defer resp.Body.Close()
 	f, err := lf.TempFileCreator.TempFile("loremflickr-img-*.jpg")
 	if err != nil {
-		log.Println("Error while creating a temp file:", err)
-		panic(err)
+		return nil, err
 	}
 
-	io.Copy(f, resp.Body)
-	return f
+	if _, err = io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	return f, nil
 }

--- a/lorem_flickr_test.go
+++ b/lorem_flickr_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestLoremFlickrImage(t *testing.T) {
 	f := New()
-	value, err := f.LoremFlickr().Image(300, 200, []string{}, "", false)
-	Expect(t, nil, err)
+	value := f.LoremFlickr().Image(300, 200, []string{}, "", false)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
@@ -17,39 +16,58 @@ func TestLoremFlickrImage(t *testing.T) {
 func TestLoremFlickrImageWithPrefix(t *testing.T) {
 	f := New()
 	for _, prefix := range []string{"g", "p", "red", "green", "blue"} {
-		value, err := f.LoremFlickr().Image(300, 200, []string{}, prefix, false)
-		Expect(t, nil, err)
+		value := f.LoremFlickr().Image(300, 200, []string{}, prefix, false)
 		Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 	}
 }
 
 func TestLoremFlickrImageWithCategories(t *testing.T) {
 	f := New()
-	value, err := f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", false)
-	Expect(t, nil, err)
+	value := f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", false)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 
-	value, err = f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", true)
-	Expect(t, nil, err)
+	value = f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", true)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
 
-func TestLoremFlickrImageErrorIfRequestFails(t *testing.T) {
+func TestLoremFlickrImagePanicIfRequestFails(t *testing.T) {
 	f := New()
 	service := f.LoremFlickr()
 	expected := fmt.Errorf("request failed")
 	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
-	_, err := service.Image(300, 200, []string{}, "", false)
-	Expect(t, expected, err)
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	service.Image(300, 200, []string{}, "", false)
 }
 
-func TestLoremFlickrImageErrorIfTempFileCreationFails(t *testing.T) {
+func TestLoremFlickrImagePanicIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	service := f.LoremFlickr()
 	expected := fmt.Errorf("temp file creation failed")
 	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	_, err := service.Image(300, 200, []string{}, "", false)
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	service.Image(300, 200, []string{}, "", false)
+}
+
+func TestLoremFlickrImageFileErrorIfRequestFails(t *testing.T) {
+	f := New()
+	service := f.LoremFlickr()
+	expected := fmt.Errorf("request failed")
+	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
+	_, err := service.ImageFile(300, 200, []string{}, "", false)
+	Expect(t, expected, err)
+}
+
+func TestLoremFlickrImageFileErrorIfTempFileCreationFails(t *testing.T) {
+	f := New()
+	service := f.LoremFlickr()
+	expected := fmt.Errorf("temp file creation failed")
+	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
+	_, err := service.ImageFile(300, 200, []string{}, "", false)
 	Expect(t, expected, err)
 }

--- a/lorem_flickr_test.go
+++ b/lorem_flickr_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestLoremFlickrImage(t *testing.T) {
 	f := New()
-	value := f.LoremFlickr().Image(300, 200, []string{}, "", false)
+	value, err := f.LoremFlickr().Image(300, 200, []string{}, "", false)
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
@@ -16,40 +17,39 @@ func TestLoremFlickrImage(t *testing.T) {
 func TestLoremFlickrImageWithPrefix(t *testing.T) {
 	f := New()
 	for _, prefix := range []string{"g", "p", "red", "green", "blue"} {
-		value := f.LoremFlickr().Image(300, 200, []string{}, prefix, false)
+		value, err := f.LoremFlickr().Image(300, 200, []string{}, prefix, false)
+		Expect(t, nil, err)
 		Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 	}
 }
 
 func TestLoremFlickrImageWithCategories(t *testing.T) {
 	f := New()
-	value := f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", false)
+	value, err := f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", false)
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 
-	value = f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", true)
+	value, err = f.LoremFlickr().Image(300, 200, []string{"cat", "dog"}, "", true)
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
 
-func TestLoremFlickrImagePanicIfRequestFails(t *testing.T) {
+func TestLoremFlickrImageErrorIfRequestFails(t *testing.T) {
 	f := New()
 	service := f.LoremFlickr()
 	expected := fmt.Errorf("request failed")
 	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	service.Image(300, 200, []string{}, "", false)
+	_, err := service.Image(300, 200, []string{}, "", false)
+	Expect(t, expected, err)
 }
 
-func TestLoremFlickrImagePanicIfTempFileCreationFails(t *testing.T) {
+func TestLoremFlickrImageErrorIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	service := f.LoremFlickr()
 	expected := fmt.Errorf("temp file creation failed")
 	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	service.Image(300, 200, []string{}, "", false)
+	_, err := service.Image(300, 200, []string{}, "", false)
+	Expect(t, expected, err)
 }

--- a/person.go
+++ b/person.go
@@ -253,7 +253,13 @@ func (p Person) Contact() ContactInfo {
 	}
 }
 
-// Image return the person profile image
-func (p Person) Image() (*os.File, error) {
+// Image return the person profile image.
+// Panics on failure to maintain backward compatibility.
+func (p Person) Image() *os.File {
 	return p.Faker.ProfileImage().Image()
+}
+
+// ImageFile return the person profile image without panicking on errors.
+func (p Person) ImageFile() (*os.File, error) {
+	return p.Faker.ProfileImage().ImageFile()
 }

--- a/person.go
+++ b/person.go
@@ -254,6 +254,6 @@ func (p Person) Contact() ContactInfo {
 }
 
 // Image return the person profile image
-func (p Person) Image() *os.File {
+func (p Person) Image() (*os.File, error) {
 	return p.Faker.ProfileImage().Image()
 }

--- a/person_test.go
+++ b/person_test.go
@@ -101,8 +101,7 @@ func TestContact(t *testing.T) {
 
 func TestPersonImage(t *testing.T) {
 	p := New().Person()
-	image, err := p.Image()
-	Expect(t, nil, err)
+	image := p.Image()
 	Expect(t, fmt.Sprintf("%T", image), "*os.File")
 	Expect(t, strings.HasSuffix(image.Name(), ".jpg"), true, image.Name())
 }

--- a/person_test.go
+++ b/person_test.go
@@ -101,7 +101,8 @@ func TestContact(t *testing.T) {
 
 func TestPersonImage(t *testing.T) {
 	p := New().Person()
-	image := p.Image()
+	image, err := p.Image()
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", image), "*os.File")
 	Expect(t, strings.HasSuffix(image.Name(), ".jpg"), true, image.Name())
 }

--- a/profile_image.go
+++ b/profile_image.go
@@ -3,6 +3,7 @@ package faker
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 )
 
@@ -19,18 +20,30 @@ type ProfileImage struct {
 }
 
 // Image generates a *os.File with a random profile image using the randomuser.me service.
-func (pi ProfileImage) Image() (*os.File, error) {
+// Panics on failure to maintain backward compatibility.
+func (pi ProfileImage) Image() *os.File {
+	f, err := pi.ImageFile()
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// ImageFile generates a *os.File with a random profile image using the randomuser.me service.
+func (pi ProfileImage) ImageFile() (*os.File, error) {
 	gender := pi.faker.RandomStringElement([]string{"women", "men"})
 	profileId := pi.faker.IntBetween(1, 99)
 	url := fmt.Sprintf("%s/%s/%s/%d.jpg", profileImageBaseURL, portraitsEndpoint, gender, profileId)
 	resp, err := pi.HTTPClient.Get(url)
 	if err != nil {
+		log.Println("Error while requesting", profileImageBaseURL, ":", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	f, err := pi.TempFileCreator.TempFile("profile-picture-img-*.jpg")
 	if err != nil {
+		log.Println("Error while creating a temp file:", err)
 		return nil, err
 	}
 

--- a/profile_image.go
+++ b/profile_image.go
@@ -3,7 +3,6 @@ package faker
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 )
 
@@ -19,24 +18,26 @@ type ProfileImage struct {
 	TempFileCreator TempFileCreator
 }
 
-// Image generates a *os.File with a random profile image using the thispersondoesnotexist.com service
-func (pi ProfileImage) Image() *os.File {
+// Image generates a *os.File with a random profile image using the randomuser.me service.
+func (pi ProfileImage) Image() (*os.File, error) {
 	gender := pi.faker.RandomStringElement([]string{"women", "men"})
 	profileId := pi.faker.IntBetween(1, 99)
 	url := fmt.Sprintf("%s/%s/%s/%d.jpg", profileImageBaseURL, portraitsEndpoint, gender, profileId)
 	resp, err := pi.HTTPClient.Get(url)
 	if err != nil {
-		log.Println("Error while requesting", profileImageBaseURL, ":", err)
-		panic(err)
+		return nil, err
 	}
+	defer resp.Body.Close()
 
 	f, err := pi.TempFileCreator.TempFile("profile-picture-img-*.jpg")
 	if err != nil {
-		log.Println("Error while creating a temp file:", err)
-		panic(err)
+		return nil, err
 	}
 
-	io.Copy(f, resp.Body)
-	resp.Body.Close()
-	return f
+	if _, err = io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	return f, nil
 }

--- a/profile_image_test.go
+++ b/profile_image_test.go
@@ -8,29 +8,26 @@ import (
 
 func TestProfileImage(t *testing.T) {
 	f := New()
-	value := f.ProfileImage().Image()
+	value, err := f.ProfileImage().Image()
+	Expect(t, nil, err)
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
 
-func TestProfileImagePanicIfRequestFails(t *testing.T) {
+func TestProfileImageErrorIfRequestFails(t *testing.T) {
 	f := New()
 	service := f.ProfileImage()
 	expected := fmt.Errorf("request failed")
 	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	service.Image()
+	_, err := service.Image()
+	Expect(t, expected, err)
 }
 
-func TestProfileImagePanicIfTempFileCreationFails(t *testing.T) {
+func TestProfileImageErrorIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	service := f.ProfileImage()
 	expected := fmt.Errorf("temp file creation failed")
 	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	defer func() {
-		Expect(t, recover(), expected)
-	}()
-	service.Image()
+	_, err := service.Image()
+	Expect(t, expected, err)
 }

--- a/profile_image_test.go
+++ b/profile_image_test.go
@@ -8,26 +8,47 @@ import (
 
 func TestProfileImage(t *testing.T) {
 	f := New()
-	value, err := f.ProfileImage().Image()
-	Expect(t, nil, err)
+	value := f.ProfileImage().Image()
 	Expect(t, fmt.Sprintf("%T", value), "*os.File")
 	Expect(t, strings.HasSuffix(value.Name(), ".jpg"), true, value.Name())
 }
 
-func TestProfileImageErrorIfRequestFails(t *testing.T) {
+func TestProfileImagePanicIfRequestFails(t *testing.T) {
 	f := New()
 	service := f.ProfileImage()
 	expected := fmt.Errorf("request failed")
 	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
-	_, err := service.Image()
-	Expect(t, expected, err)
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	service.Image()
 }
 
-func TestProfileImageErrorIfTempFileCreationFails(t *testing.T) {
+func TestProfileImagePanicIfTempFileCreationFails(t *testing.T) {
 	f := New()
 	service := f.ProfileImage()
 	expected := fmt.Errorf("temp file creation failed")
 	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
-	_, err := service.Image()
+	defer func() {
+		Expect(t, recover(), expected)
+	}()
+	service.Image()
+}
+
+func TestProfileImageFileErrorIfRequestFails(t *testing.T) {
+	f := New()
+	service := f.ProfileImage()
+	expected := fmt.Errorf("request failed")
+	service.HTTPClient = ErrorRaiserHTTPClient{err: expected}
+	_, err := service.ImageFile()
+	Expect(t, expected, err)
+}
+
+func TestProfileImageFileErrorIfTempFileCreationFails(t *testing.T) {
+	f := New()
+	service := f.ProfileImage()
+	expected := fmt.Errorf("temp file creation failed")
+	service.TempFileCreator = ErrorRaiserTempFileCreator{err: expected}
+	_, err := service.ImageFile()
 	Expect(t, expected, err)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds error-returning image methods without changing existing function signatures.

## Changes

- **Unchanged**: `Image()` methods keep returning `*os.File` and panic on failure
- **New**: `ImageFile()` methods on `LoremFlickr`, `ProfileImage`, `Image`, and `Person` return `(*os.File, error)`
- `Image()` delegates to `ImageFile()` and panics on error
- Tests cover both panic behavior (existing API) and error returns (new API)

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

