### PR TITLE
Strengthen smoke-only provider tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,15 +1,18 @@
 package faker
 
 import (
+	"regexp"
+	"slices"
 	"testing"
 )
 
 func TestAppName(t *testing.T) {
-	a := New().App()
-	NotExpect(t, "", a.Name())
+	v := New().App().Name()
+	Expect(t, true, slices.Contains(appNames, v))
 }
 
 func TestAppVersion(t *testing.T) {
-	a := New().App()
-	NotExpect(t, "", a.Version())
+	v := New().App().Version()
+	re := regexp.MustCompile(`^v\d\.\d\.\d$`)
+	Expect(t, true, re.MatchString(v))
 }

--- a/blood_test.go
+++ b/blood_test.go
@@ -1,11 +1,13 @@
 package faker
 
 import (
+	"slices"
 	"testing"
 )
 
+var expectedBloodTypes = []string{"A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"}
+
 func TestBloodName(t *testing.T) {
 	v := New().Blood().Name()
-	NotExpect(t, "", v)
-	ExpectInString(t, v, bloodTypes)
+	Expect(t, true, slices.Contains(expectedBloodTypes, v))
 }

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -1,15 +1,16 @@
 package faker
 
 import (
+	"slices"
 	"testing"
 )
 
 func TestEmoji(t *testing.T) {
-	e := New().Emoji()
-	NotExpect(t, "", e.Emoji())
+	v := New().Emoji().Emoji()
+	Expect(t, true, slices.Contains(emojis, v))
 }
 
 func TestEmojiCode(t *testing.T) {
-	e := New().Emoji()
-	NotExpect(t, "", e.EmojiCode())
+	v := New().Emoji().EmojiCode()
+	Expect(t, true, slices.Contains(emojisCode, v))
 }

--- a/food_test.go
+++ b/food_test.go
@@ -1,15 +1,16 @@
 package faker
 
 import (
+	"slices"
 	"testing"
 )
 
-func TestFoodFruit(t *testing.T) {
+func TestFruit(t *testing.T) {
 	v := New().Food().Fruit()
-	NotExpect(t, "", v)
+	Expect(t, true, slices.Contains(fruits, v))
 }
 
-func TestFoodVegetable(t *testing.T) {
+func TestVegetable(t *testing.T) {
 	v := New().Food().Vegetable()
-	NotExpect(t, "", v)
+	Expect(t, true, slices.Contains(vegetables, v))
 }

--- a/gamer_test.go
+++ b/gamer_test.go
@@ -1,10 +1,11 @@
 package faker
 
 import (
+	"slices"
 	"testing"
 )
 
 func TestTag(t *testing.T) {
 	v := New().Gamer().Tag()
-	NotExpect(t, "", v)
+	Expect(t, true, slices.Contains(gamerTags, v))
 }

--- a/gender_test.go
+++ b/gender_test.go
@@ -1,17 +1,16 @@
 package faker
 
 import (
+	"slices"
 	"testing"
 )
 
 func TestGenderName(t *testing.T) {
 	v := New().Gender().Name()
-	NotExpect(t, "", v)
-	Expect(t, true, v == "masculine" || v == "feminine")
+	Expect(t, true, slices.Contains([]string{"masculine", "feminine"}, v))
 }
 
 func TestGenderAbbr(t *testing.T) {
 	v := New().Gender().Abbr()
-	NotExpect(t, "", v)
-	Expect(t, true, v == "masc" || v == "fem")
+	Expect(t, true, slices.Contains([]string{"masc", "fem"}, v))
 }

--- a/genre_test.go
+++ b/genre_test.go
@@ -6,11 +6,13 @@ import (
 
 func TestGenreName(t *testing.T) {
 	v := New().Genre().Name()
-	NotExpect(t, "", v)
+	_, ok := genres[v]
+	Expect(t, true, ok)
 }
 
 func TestGenreNameWithDescription(t *testing.T) {
-	name, description := New().Genre().NameWithDescription()
-	NotExpect(t, "", name)
-	NotExpect(t, "", description)
+	name, desc := New().Genre().NameWithDescription()
+	Expect(t, true, len(name) > 0)
+	Expect(t, true, len(desc) > 0)
+	Expect(t, genres[name], desc)
 }

--- a/mimetype_test.go
+++ b/mimetype_test.go
@@ -1,10 +1,13 @@
 package faker
 
 import (
+	"slices"
+	"strings"
 	"testing"
 )
 
 func TestMimeType(t *testing.T) {
-	p := New().MimeType()
-	Expect(t, true, p.MimeType() != "")
+	v := New().MimeType().MimeType()
+	Expect(t, true, slices.Contains(mimeType, v))
+	Expect(t, true, strings.Contains(v, "/"))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces minimal non-empty smoke tests with assertions that verify values come from known datasets or match expected formats.

## Changes

- Gamer, blood, food, gender, emoji, app: assert membership in provider data lists
- MimeType: assert `type/subtype` format
- App: validate version regex pattern
- Genre: verify name exists in map and description matches

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

