### PR TITLE
Guard RandomElement and map helpers against empty input

### DIFF
--- a/random_element.go
+++ b/random_element.go
@@ -1,7 +1,12 @@
 package faker
 
-// RandomElement returns a fake random element from a given list of elements
+// RandomElement returns a fake random element from a given list of elements.
+// Returns the zero value when elements is empty.
 func RandomElement[T any](f Faker, elements ...T) T {
+	if len(elements) == 0 {
+		var zero T
+		return zero
+	}
 	i := f.IntBetween(0, len(elements)-1)
 	return elements[i]
 }
@@ -45,6 +50,10 @@ func RandomElementWeighted[T any](f Faker, elements map[int]T) T {
 }
 
 func RandomMapKey[K comparable, V any](f Faker, m map[K]V) K {
+	if len(m) == 0 {
+		var zero K
+		return zero
+	}
 	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -55,6 +64,10 @@ func RandomMapKey[K comparable, V any](f Faker, m map[K]V) K {
 }
 
 func RandomMapValue[K comparable, V any](f Faker, m map[K]V) V {
+	if len(m) == 0 {
+		var zero V
+		return zero
+	}
 	values := make([]V, 0, len(m))
 	for k := range m {
 		values = append(values, m[k])

--- a/random_element_test.go
+++ b/random_element_test.go
@@ -47,3 +47,21 @@ func TestRandomMapValue(t *testing.T) {
 	randomStr := RandomMapValue(f, m)
 	Expect(t, true, randomStr == "one" || randomStr == "five" || randomStr == "forty two")
 }
+
+func TestRandomElementEmpty(t *testing.T) {
+	f := New()
+	var zero string
+	Expect(t, zero, RandomElement[string](f))
+}
+
+func TestRandomMapKeyEmpty(t *testing.T) {
+	f := New()
+	var zero int
+	Expect(t, zero, RandomMapKey[int, string](f, map[int]string{}))
+}
+
+func TestRandomMapValueEmpty(t *testing.T) {
+	f := New()
+	var zero string
+	Expect(t, zero, RandomMapValue[int, string](f, map[int]string{}))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents panics when generic random selection helpers receive empty inputs.

## Changes

- `RandomElement` returns zero value for empty slices
- `RandomMapKey` and `RandomMapValue` return zero values for empty maps
- Add tests for all empty input cases

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

