### PR TITLE
Add generator catalog table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,31 @@ fmt.Println(profileImage.Name())
 // /tmp/profil-picture-img-4022222298.jfif
 ```
 
-See more formatters in [docs](https://pkg.go.dev/github.com/jaswdr/faker?tab=doc)
+See more formatters in [docs](https://pkg.go.dev/github.com/jaswdr/faker/v2?tab=doc)
+
+## Generator Catalog
+
+Access generators via `f := faker.New()` then `f.<Provider>().<Method>()`.
+
+| Provider | Key methods | Description |
+|----------|-------------|-------------|
+| `Person()` | `Name`, `FirstName`, `LastName`, `SSN`, `Contact`, `Image` | People and identity |
+| `Address()` | `Address`, `City`, `State`, `ZipCode`, `Latitude`, `Longitude` | US-style addresses |
+| `Phone()` | `Number`, `E164Number`, `TollFreeNumber` | Phone numbers |
+| `Internet()` | `Email`, `URL`, `IPv4`, `IPv6`, `Password`, `UserAgent` | Web and network data |
+| `Company()` | `Name`, `CatchPhrase`, `JobTitle`, `EIN` | Business data |
+| `Payment()` | `CreditCardType`, `CreditCardNumber`, `CreditCardExpirationDateString` | Payment cards |
+| `Lorem()` | `Word`, `Sentence`, `Paragraph`, `Text` | Placeholder text |
+| `Time()` | `Recent`, `Past`, `Soon`, `Future`, `ISO8601`, `RFC3339` | Dates and times |
+| `UUID()` | `V4` | UUID generation |
+| `Color()` | `Hex`, `RGB`, `SafeColorName` | Colors |
+| `File()` / `Directory()` | `Extension`, `Path`, `AbsolutePath` | File system paths |
+| `Struct()` | `Fill`, `FillWithDepth`, `RegisterFunction` | Struct tag filling |
+| `Crypto()` | `BitcoinAddress`, `EthereumAddress` | Crypto addresses |
+| `Image()` / `LoremFlickr()` / `ProfileImage()` | `Image` | Generated or remote images |
+| `Beer()`, `Car()`, `Food()`, `Pet()`, `Gamer()`, `Pokemon()`, `Music()`, `YouTube()` | various | Specialty datasets |
+
+Core formatting helpers on `Faker` itself: `Numerify`, `Lexify`, `Bothify`, `Asciify`, `IntBetween`, `Bool`, `BoolWithChance`.
 
 ## Development
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a generator catalog to the README so users can discover available providers without browsing pkg.go.dev.

## Changes

- Add table of major providers with key methods and descriptions
- Document core `Faker` formatting helpers
- Fix pkg.go.dev link to v2 module path

## Testing

- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5098-8778-7cba-bdfd-ec321225281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

